### PR TITLE
Uniform coding style for brace of function

### DIFF
--- a/example/coapapp/coapapp.c
+++ b/example/coapapp/coapapp.c
@@ -166,7 +166,8 @@ int application_start(void)
     return 0;
 }
 
-static void ota_init(){
+static void ota_init()
+{
     ota_device_info.product_key=IOTX_PRODUCT_KEY;
     ota_device_info.device_name=IOTX_DEVICE_NAME;
     ota_device_info.h_coap=p_ctx;

--- a/example/mqttapp/mqtt-example-b_l475e.c
+++ b/example/mqttapp/mqtt-example-b_l475e.c
@@ -413,7 +413,8 @@ int application_start(int argc, char *argv[])
     return 0;
 }
 
-static void ota_init(){
+static void ota_init()
+{
     input_event_t event;
     event.type = EV_SYS;
     event.code = CODE_SYS_ON_START_FOTA;

--- a/example/mqttapp/mqtt-example.c
+++ b/example/mqttapp/mqtt-example.c
@@ -369,7 +369,8 @@ int application_start(int argc, char *argv[])
     return 0;
 }
 
-static void ota_init(void *pclient){
+static void ota_init(void *pclient)
+{
     ota_device_info.product_key=PRODUCT_KEY;
     ota_device_info.device_name=DEVICE_NAME;
     ota_device_info.pclient=pclient;


### PR DESCRIPTION
I search the whole project and find the three places where function parameters list are immediately followed by left brace `{` without a new line.