### PR TITLE
Fix the bug that CLI command 'time' always returns 0

### DIFF
--- a/tools/cli/cli.c
+++ b/tools/cli/cli.c
@@ -639,7 +639,7 @@ static void reboot_cmd(char *buf, int len, int argc, char **argv)
 
 static void uptime_cmd(char *buf, int len, int argc, char **argv)
 {
-    aos_cli_printf("UP time %ldms\r\n", aos_now_ms());
+    aos_cli_printf("UP time %ld ms\r\n", (long)aos_now_ms());
 }
 
 void tftp_ota_thread(void *arg)


### PR DESCRIPTION
Because printf relevant function provided by C library don't support long long type, CLI command `time` always returns 0. 
For more detail, see https://github.com/alibaba/AliOS-Things/issues/20 