### PR TITLE
Exit alinkapp@linuxhost when it calls platform_sys_reboot

### DIFF
--- a/framework/protocol/alink/os/platform/linux_hardware.c
+++ b/framework/protocol/alink/os/platform/linux_hardware.c
@@ -271,8 +271,7 @@ int platform_sys_net_is_ready(void)
 
 void platform_sys_reboot(void)
 {
-    int ret = 0;
-    ret = system(REBOOT_CMD);
+    exit(0);
 }
 
 char *platform_get_module_name(char name_str[STR_SHORT_LEN])


### PR DESCRIPTION
Example alinkapp@linuxhost will reboot my linux host when execution shell cmd `reset` to do factory reset. It's better to exit app rather than reboot linux host.