### PR TITLE
[FRDMKL27Z]Add YLOOP certificate test in FRDMKL27Z IAR project

### DIFF
--- a/platform/mcu/mkl27z644/aos/aos.c
+++ b/platform/mcu/mkl27z644/aos/aos.c
@@ -22,6 +22,8 @@
 #define AOS_START_STACK 256
 
 extern int application_start(int argc, char **argv);
+extern int vfs_init(void);
+extern int vfs_device_init(void);
 extern uart_dev_t uart_0;
 
 ktask_t *g_aos_app;
@@ -29,6 +31,8 @@ static void sys_init(void)
 {
 
 #ifdef AOS_LOOP
+    vfs_init();
+    vfs_device_init();
     aos_loop_init();
 #endif
     application_start(0, NULL);	

--- a/projects/IAR/frdmkl27_yts/kernel_yts.ewp
+++ b/projects/IAR/frdmkl27_yts/kernel_yts.ewp
@@ -235,7 +235,7 @@
                     <state>SYSINFO_ARCH="Cortex-M0"</state>
                     <state>SYSINFO_MCU="mkl27z644"</state>
                     <state>TEST_CONFIG_KV_ENABLED=0</state>
-                    <state>TEST_CONFIG_YLOOP_ENABLED=0</state>
+                    <state>TEST_CONFIG_YLOOP_ENABLED=1</state>
                 </option>
                 <option>
                     <name>CCPreprocFile</name>
@@ -1284,7 +1284,7 @@
                     <state>SYSINFO_ARCH="Cortex-M0"</state>
                     <state>SYSINFO_MCU="mkl27z644"</state>
                     <state>TEST_CONFIG_KV_ENABLED=0</state>
-                    <state>TEST_CONFIG_YLOOP_ENABLED=0</state>
+                    <state>TEST_CONFIG_YLOOP_ENABLED=1</state>
                 </option>
                 <option>
                     <name>CCPreprocFile</name>


### PR DESCRIPTION
- Add vfs and vfs_device init in system init for yloop.
- Define YLOOP_TEST_ENABLE macro in IAR project to 1.

Signed-off-by: Kong Li <li.kong@nxp.com>