### PR TITLE
[FRDMKL27 IAR]Fix IAR project linker file issue

### DIFF
--- a/projects/IAR/frdmkl27_yts/kernel_yts.ewp
+++ b/projects/IAR/frdmkl27_yts/kernel_yts.ewp
@@ -791,7 +791,7 @@
                 </option>
                 <option>
                     <name>IlinkIcfFile</name>
-                    <state>D:\code\alios-things\platform\mcu\mkl27z644\iar\MKL27Z64xxx4_flash.icf</state>
+                    <state>$PROJ_DIR$\..\..\..\platform\mcu\mkl27z644\iar\MKL27Z64xxx4_flash.icf</state>
                 </option>
                 <option>
                     <name>IlinkIcfFileSlave</name>
@@ -1840,7 +1840,7 @@
                 </option>
                 <option>
                     <name>IlinkIcfFile</name>
-                    <state>D:\code\alios-things\platform\mcu\mkl27z644\iar\MKL27Z64xxx4_flash.icf</state>
+                    <state>$PROJ_DIR$\..\..\..\platform\mcu\mkl27z644\iar\MKL27Z64xxx4_flash.icf</state>
                 </option>
                 <option>
                     <name>IlinkIcfFileSlave</name>


### PR DESCRIPTION
- Shall use relative path, not absolute path for linker file.

Signed-off-by: Kong Li <li.kong@nxp.com>