### PR TITLE
fix coapapp@b_l475e compile problem

### DIFF
--- a/device/sal/include/sal_ipaddr.h
+++ b/device/sal/include/sal_ipaddr.h
@@ -88,6 +88,10 @@ char *ip4addr_ntoa(const ip4_addr_t *addr);
 #define inet_addr(cp) ipaddr_addr(cp)
 #define inet_aton(cp,addr) ip4addr_aton(cp,(ip4_addr_t*)addr)
 #define inet_ntoa(addr) ip4addr_ntoa((const ip4_addr_t*)&(addr))
+#define inet_ntop(af,src,dst,size) \
+    (((af) == AF_INET) ? ip4addr_ntoa_r((const ip4_addr_t*)(src),(dst),(size)) : NULL)
+#define inet_pton(af,src,dst) \
+    (((af) == AF_INET) ? ip4addr_aton((src),(ip4_addr_t*)(dst)) : 0)
 
 
 #ifdef __cplusplus

--- a/device/sal/include/sal_sockets.h
+++ b/device/sal/include/sal_sockets.h
@@ -30,6 +30,11 @@ extern "C" {
 #define SOCK_DGRAM      2
 #define SOCK_RAW        3
 
+#define IP_MULTICAST_TTL   5
+#define IP_MULTICAST_IF    6
+#define IP_MULTICAST_LOOP  7
+
+
 /* If your port already typedef's sa_family_t, define SA_FAMILY_T_DEFINED
    to prevent this code from redefining it. */
 #if !defined(sa_family_t) && !defined(SA_FAMILY_T_DEFINED)
@@ -215,7 +220,7 @@ struct hostent *sal_gethostbyname(const char *name);
 
 int sal_close(int s);
 
-int sal_init();
+int sal_init(void);
 
 int sal_sendto(int s, const void *data, size_t size, int flags, const struct sockaddr *to, socklen_t tolen);
 

--- a/example/coapapp/coapapp.c
+++ b/example/coapapp/coapapp.c
@@ -5,7 +5,7 @@
 #include <stdio.h>
 
 #ifdef PLATFORM_NOT_LINUX
-#include <lwip/inet.h>
+#include <aos/network.h>
 #else
 #include <arpa/inet.h>
 #endif

--- a/utility/iotx-utils/hal/rhino/HAL_UDP_rhino.c
+++ b/utility/iotx-utils/hal/rhino/HAL_UDP_rhino.c
@@ -6,8 +6,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <aos/log.h>
-#include <posix/sys/socket.h>
-#include <lwip/netdb.h>
+#include <aos/network.h>
 //#include "coap_transport.h"
 #include "iot_import_coap.h"
 


### PR DESCRIPTION
fix coapapp@b_l475e compile problem.
alios networks support lwip add SAL。if we want to use alios networks ,when should include <aos/network.h>。Don't use lwip functions or head files directly。