### PR TITLE
[VFS] Use macro to control the aos uart instance

### DIFF
--- a/kernel/vfs/vfs.c
+++ b/kernel/vfs/vfs.c
@@ -578,14 +578,18 @@ int aos_mkdir(const char *path)
     return ret;
 }
 
-extern uart_dev_t uart_0;
+#ifndef AOS_UART
+#define AOS_UART uart_0
+#endif
+
+extern uart_dev_t AOS_UART;
 
 int32_t aos_uart_send(void *data, uint32_t size, uint32_t timeout)
 {
-    return hal_uart_send(&uart_0, data, size, timeout);
+    return hal_uart_send(&AOS_UART, data, size, timeout);
 }
 
 int32_t aos_uart_recv(void *data, uint32_t expect_size, uint32_t *recv_size, uint32_t timeout)
 {
-    return hal_uart_recv_II(&uart_0, data,  expect_size, recv_size,  timeout);
+    return hal_uart_recv_II(&AOS_UART, data,  expect_size, recv_size,  timeout);
 }


### PR DESCRIPTION
 - Add macro AOS_UART for the uart instance, this
   macro is uart_0 by default, application could define
   in board level to override it.

Signed-off-by: Jason Yu <zejiang.yu@nxp.com>