### PR TITLE
[BUILD] Support build in Windows Subsystem Linux(WSL)

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -1,5 +1,7 @@
 default: Help
 
+unexport NAME # For compatibility with Windows Subsystem Linux
+
 export AOS_SDK_VERSION_MAJOR    :=  3
 export AOS_SDK_VERSION_MINOR    :=  2
 export AOS_SDK_VERSION_REVISION :=  3


### PR DESCRIPTION
 - WSL defines enviroment variable NAME, conflict with
   the build framework. This patch unexport NAME at
   the beginning of Makefile

Signed-off-by: Jason Yu <zejiang.yu@nxp.com>