### PR TITLE
[Developerkit]: Fix Black Screen issue when running ldapp

### DIFF
--- a/board/developerkit/Src/main.c
+++ b/board/developerkit/Src/main.c
@@ -199,7 +199,7 @@ void SystemClock_Config(void)
   RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_MSI;
   RCC_OscInitStruct.PLL.PLLM = 1;
-  RCC_OscInitStruct.PLL.PLLN = 65;
+  RCC_OscInitStruct.PLL.PLLN = 40;
   RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
   RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
   RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;


### PR DESCRIPTION
Issue description:
  The sensor data can be showned on LCD, meanwhile, sensor data
  can be published via mqtt. But about 20 seconds or shaking the kits
  with a little time, LCD screen will be off and never be recovery back.

Root cause:
   LCD RST pin will be pulled low at least 0.7 second when issue happened,
   this pin also be wrong configured as Als LED, it will be pulled low if lux<=40.

Note:
 RCC_OscInitStruct.PLL.PLLN need to be set as 40 instead of 65, confirm with Notion/ST

More details please find more via Aone,
https://aone.alibaba-inc.com/project/690191/issue/15774169