### PR TITLE
Fix ATSAME54 buffer overflow issue

### DIFF
--- a/board/atsame54-xpro/atsame54-xpro.mk
+++ b/board/atsame54-xpro/atsame54-xpro.mk
@@ -14,6 +14,7 @@ GLOBAL_INCLUDES += .
 
 GLOBAL_DEFINES += STDIO_UART=2
 
+ywss_support ?= 0
 sal ?= 1
 ifeq (1,$(sal))
 $(NAME)_COMPONENTS += sal
@@ -28,8 +29,3 @@ CONFIG_SYSINFO_DEVICE_NAME := ATSAME54
 GLOBAL_CFLAGS += -DSYSINFO_OS_VERSION=\"$(CONFIG_SYSINFO_OS_VERSION)\"
 GLOBAL_CFLAGS += -DSYSINFO_PRODUCT_MODEL=\"$(CONFIG_SYSINFO_PRODUCT_MODEL)\"
 GLOBAL_CFLAGS += -DSYSINFO_DEVICE_NAME=\"$(CONFIG_SYSINFO_DEVICE_NAME)\"
-
-# Define default component testcase set
-ifneq (, $(findstring yts, $(BUILD_STRING)))
-TEST_COMPONENTS += basic api wifi_hal rhino kv yloop alicrypto cjson digest_algorithm hashtable
-endif

--- a/platform/mcu/atsamd5x_e5x/Drivers/hal/src/hal_usart_os.c
+++ b/platform/mcu/atsamd5x_e5x/Drivers/hal/src/hal_usart_os.c
@@ -45,7 +45,7 @@
  * \brief Maximum amount of USART interface instances
  */
 #define MAX_USART_AMOUNT SERCOM_INST_NUM
-#define MAX_BUF_UART_BYTES  1024
+#define MAX_BUF_UART_BYTES  2048
 static int32_t usart_os_write(struct io_descriptor *const io_descr, const uint8_t *const buf, const uint16_t length, uint32_t timeout);
 static int32_t usart_sync_write(struct io_descriptor *const io_descr, const uint8_t *const buf, const uint16_t length, uint32_t timeout);
 static int32_t usart_os_read(struct io_descriptor *const io_descr, uint8_t *const buf, const uint16_t length, uint32_t timeout);

--- a/platform/mcu/atsamd5x_e5x/Drivers/hal/src/hal_usart_os.c
+++ b/platform/mcu/atsamd5x_e5x/Drivers/hal/src/hal_usart_os.c
@@ -437,7 +437,7 @@ static int32_t usart_sync_write(struct io_descriptor *const io_descr, const uint
 		return -1;
 	}
 	/* Flush unexpected data */
-	krhino_buf_queue_flush(&descr->kbuf);
+	//krhino_buf_queue_flush(&descr->kbuf);
 
 	do {
 		_usart_sync_write_byte(&descr->sync_device, buf[offset]);

--- a/platform/mcu/atsamd5x_e5x/aos/aos.c
+++ b/platform/mcu/atsamd5x_e5x/aos/aos.c
@@ -9,7 +9,7 @@
 #include <hal/soc/soc.h>
 #include <hal/wifi.h>
 
-#define AOS_START_STACK 1024
+#define AOS_START_STACK 1536
 
 ktask_t *g_aos_init;
 static kinit_t kinit;
@@ -38,7 +38,7 @@ static void sys_init(void)
     board_init();
     aos_kernel_init(&kinit);
 
-    application_start(0, NULL);	
+    application_start(0, NULL);
 }
 
 int main(void)


### PR DESCRIPTION
1. Fix UART overflow issue.
2. Append aos-init task stack size for fix OVF issue.
3. Fix mk file for linkkitapp demo.