### PR TITLE
lwip socket timeout data type

### DIFF
--- a/example/networkapp/networkapp.c
+++ b/example/networkapp/networkapp.c
@@ -30,7 +30,6 @@ static int networktestcmd_tcp_client(int argc, char **argv)
     char *pcdata = NULL;
     char *pctesttime = NULL;
     struct sockaddr_in addr;
-    struct timeval timeout;
     
     if (argc < 5){
         printf("invalid input tcp clinet test command \r\n");
@@ -73,8 +72,14 @@ static int networktestcmd_tcp_client(int argc, char **argv)
         return -1;
     }
     
+#if LWIP_SO_SNDRCVTIMEO_NONSTANDARD
+    int timeout;
+    timeout = 30 * 1000; //set recvive timeout = 30(sec)
+#else
+    struct timeval timeout;
     timeout.tv_sec = 30;
     timeout.tv_usec = 0;
+#endif
 
     if (setsockopt (fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout,
                     sizeof(timeout)) < 0) {

--- a/example/tls/tls_client.c
+++ b/example/tls/tls_client.c
@@ -59,7 +59,6 @@ void *network_socket_create(const char *net_addr, int port)
     int tcp_fd;
     struct hostent *host;
     struct sockaddr_in saddr;
-    int opt_val = 1;
 
     set_errno(0);
     tcp_fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -79,7 +78,16 @@ void *network_socket_create(const char *net_addr, int port)
     saddr.sin_port = htons(port);
     saddr.sin_addr.s_addr = *(unsigned long *)(host->h_addr);
 
-    setsockopt(tcp_fd, SOL_SOCKET, SO_RCVTIMEO, &opt_val, sizeof(opt_val));
+#if LWIP_SO_SNDRCVTIMEO_NONSTANDARD
+    int timeout;
+    timeout = 1 * 1000; //set recvive timeout = 20(sec)
+#else
+    struct timeval timeout;
+    timeout.tv_sec = 1;
+    timeout.tv_usec = 0;
+#endif
+
+    setsockopt(tcp_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
 
     do {
         set_errno(0);

--- a/framework/fota/download/http/socket/stand/ota_socket.c
+++ b/framework/fota/download/http/socket/stand/ota_socket.c
@@ -29,9 +29,13 @@ int ota_socket_connect(int port, char *host_addr)
         return -1;
     }
 
+#if LWIP_SO_SNDRCVTIMEO_NONSTANDARD
+    int timeout = 10*1000;
+#else
     struct timeval timeout;
     timeout.tv_sec = 10;
     timeout.tv_usec = 0;
+#endif
 
     if (setsockopt (sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout,
                     sizeof(timeout)) < 0) {

--- a/kernel/protocols/net/apps/lwiperf/iperf_task.c
+++ b/kernel/protocols/net/apps/lwiperf/iperf_task.c
@@ -174,8 +174,14 @@ void iperf_udp_run_server( char *parameters[] )
     UDP_datagram *udp_h;
     client_hdr *client_h;
     client_hdr client_h_trans;
+#if LWIP_SO_SNDRCVTIMEO_NONSTANDARD
     uint32_t timeout;
     timeout = 20 * 1000; //set recvive timeout = 20(sec)
+#else
+    struct timeval timeout;
+    timeout.tv_sec = 20;
+    timeout.tv_usec = 0;
+#endif
     int is_test_started = 0;
     int udp_h_id = 0;
 
@@ -454,8 +460,14 @@ void iperf_tcp_run_server( char *parameters[] )
     uint32_t t1, t2, curr_t;
     int offset = IPERF_COMMAND_BUFFER_SIZE / sizeof(char *);
     char *buffer = (char*) malloc( IPERF_TEST_BUFFER_SIZE );
+#if LWIP_SO_SNDRCVTIMEO_NONSTANDARD
     uint32_t timeout;
     timeout = 20 * 1000; //set recvive timeout = 20(sec)
+#else
+    struct timeval timeout;
+    timeout.tv_sec = 20;
+    timeout.tv_usec = 0;
+#endif
 
     memset( buffer, 0, IPERF_TEST_BUFFER_SIZE );
     //Statistics init

--- a/test/testcase/security/tls_test/tls_test.c
+++ b/test/testcase/security/tls_test/tls_test.c
@@ -75,7 +75,6 @@ static void *network_socket_create(const char *net_addr, int port)
     int tcp_fd;
     struct hostent *host;
     struct sockaddr_in saddr;
-    int opt_val = 1;
 
     tcp_fd = socket(AF_INET, SOCK_STREAM, 0);
     if (tcp_fd < 0) {
@@ -94,7 +93,16 @@ static void *network_socket_create(const char *net_addr, int port)
     saddr.sin_port = htons(port);
     saddr.sin_addr.s_addr = *(unsigned long *)(host->h_addr);
 
-    setsockopt(tcp_fd, SOL_SOCKET, SO_RCVTIMEO, &opt_val, sizeof(opt_val));
+#if LWIP_SO_SNDRCVTIMEO_NONSTANDARD
+    int timeout;
+    timeout = 1 * 1000; //set recvive timeout = 20(sec)
+#else
+    struct timeval timeout;
+    timeout.tv_sec = 1;
+    timeout.tv_usec = 0;
+#endif
+
+    setsockopt(tcp_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
 
     do {
         set_errno(0);


### PR DESCRIPTION
lwip accepts timeout as int or struct timeval, according to LWIP_SO_SNDRCVTIMEO_NONSTANDARD in the options. And old lwip (for some platform use private lwip) supports int timeout only.