### PR TITLE
Modify STACK allocate, add MARK for UART initialized: aone ID 16720373

### DIFF
--- a/platform/mcu/stm32l4xx_cube/aos/soc_impl.c
+++ b/platform/mcu/stm32l4xx_cube/aos/soc_impl.c
@@ -46,18 +46,8 @@ void soc_intrpt_stack_ovf_check(void)
 #if (RHINO_CONFIG_MM_TLF > 0)
 
 #if defined (__CC_ARM) /* Keil / armcc */
-#if 1
-#define HEAP_BUFFER_SIZE 1024*30
-uint8_t g_heap_buf[HEAP_BUFFER_SIZE];
-k_mm_region_t g_mm_region[1];
-int           g_region_num = 1;
-void aos_heap_set(void)
-{
-    g_mm_region[0].start = g_heap_buf;
-    g_mm_region[0].len   = HEAP_BUFFER_SIZE;
-}
-#else
 extern unsigned int Image$$RW_IRAM1$$ZI$$Limit;
+//comes from component board, may different to each other as hardware resource
 extern size_t g_iram1_start;
 extern size_t g_iram1_total_size;
 k_mm_region_t g_mm_region[1];
@@ -69,7 +59,6 @@ void aos_heap_set(void)
         (g_iram1_start + g_iram1_total_size - (size_t)&Image$$RW_IRAM1$$ZI$$Limit);
 	  printf("g_mm_region[0].start is 0x%x, g_mm_region[0].len is 0x%x \r\n", (size_t)g_mm_region[0].start, g_mm_region[0].len);
 }
-#endif
 #elif defined (__ICCARM__)/* IAR */
 #define HEAP_BUFFER_SIZE 1024*20
 uint8_t g_heap_buf[HEAP_BUFFER_SIZE];

--- a/platform/mcu/stm32l4xx_cube/hal/hal_uart_stm32l4.c
+++ b/platform/mcu/stm32l4xx_cube/hal/hal_uart_stm32l4.c
@@ -12,10 +12,6 @@
 
 #ifdef HAL_UART_MODULE_ENABLED
 
-/* Init function for uart1 */
-static int32_t uart1_init(uart_dev_t *uart);
-static int32_t uart2_init(uart_dev_t *uart);
-
 /* function used to transform hal para to stm32l4 para */
 static int32_t uart_dataWidth_transform(hal_uart_data_width_t data_width_hal, uint32_t *data_width_stm32l4);
 static int32_t uart_parity_transform(hal_uart_parity_t parity_hal, uint32_t *parity_stm32l4);
@@ -39,6 +35,7 @@ typedef struct {
   aos_mutex_t uart_rx_mutex;
   aos_sem_t uart_tx_sem;
   aos_sem_t uart_rx_sem;
+  uint8_t   initialized;
 }stm32_uart_t;
 
 stm32_uart_t stm32_uart[PORT_UART_MAX_NUM];
@@ -219,6 +216,7 @@ int32_t hal_uart_init(uart_dev_t *uart)
     aos_mutex_new(&stm32_uart[uart->port].uart_rx_mutex);
     aos_sem_new(&stm32_uart[uart->port].uart_tx_sem, 0);
     aos_sem_new(&stm32_uart[uart->port].uart_rx_sem, 0);
+    stm32_uart[uart->port].initialized = 1;
     return ret;
 }
 
@@ -288,6 +286,10 @@ int32_t hal_uart_send(uart_dev_t *uart, const void *data, uint32_t size, uint32_
 
     handle = uart_get_handle(uart->port);
     if (handle == NULL) {
+        return -1;
+    }
+    
+    if( !stm32_uart[uart->port].initialized ) {
         return -1;
     }
 


### PR DESCRIPTION
2 Minor Modification:
Modify STACK allocate under Keil MDK;
Add MARK for UART initialized;

which are used to make possible that generate STM32L4XX project via CubeMX.