### PR TITLE
Remove sys/wait.h in yts_main.c

### DIFF
--- a/test/testcase/yts_main.c
+++ b/test/testcase/yts_main.c
@@ -4,9 +4,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#if defined (__GNUC__)
-#include <sys/wait.h>
-#endif
 
 #include <aos/kernel.h>
 


### PR DESCRIPTION
Remove sys/wait.h since no code depends on this header file. And wait.h brings error to compilation if "-gnu" flag is open in rvct.