### PR TITLE
I2C HAL for ESP32 fixed, native sensor support for Sensirion SPS30 and Bosch BME680 added.

### DIFF
--- a/device/sensor/drv/drv_gr_baro_temp_hum_bosch_bme680/bme680.c
+++ b/device/sensor/drv/drv_gr_baro_temp_hum_bosch_bme680/bme680.c
@@ -1,0 +1,1367 @@
+/**\mainpage
+ * Copyright (C) 2017 - 2018 Bosch Sensortec GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of the copyright holder nor the names of the
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES(INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+ *
+ * The information provided is believed to be accurate and reliable.
+ * The copyright holder assumes no responsibility
+ * for the consequences of use
+ * of such information nor for any infringement of patents or
+ * other rights of third parties which may result from its use.
+ * No license is granted by implication or otherwise under any patent or
+ * patent rights of the copyright holder.
+ *
+ * File		bme680.c
+ * @date	19 Jun 2018
+ * @version	3.5.9
+ *
+ */
+
+/*! @file bme680.c
+ @brief Sensor driver for BME680 sensor */
+#include "bme680.h"
+
+/*!
+ * @brief This internal API is used to read the calibrated data from the sensor.
+ *
+ * This function is used to retrieve the calibration
+ * data from the image registers of the sensor.
+ *
+ * @note Registers 89h  to A1h for calibration data 1 to 24
+ *        from bit 0 to 7
+ * @note Registers E1h to F0h for calibration data 25 to 40
+ *        from bit 0 to 7
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status.
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t get_calib_data(struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to set the gas configuration of the sensor.
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status.
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t set_gas_config(struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to get the gas configuration of the sensor.
+ * @note heatr_temp and heatr_dur values are currently register data
+ * and not the actual values set
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status.
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t get_gas_config(struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the Heat duration value.
+ *
+ * @param[in] dur	:Value of the duration to be shared.
+ *
+ * @return uint8_t threshold duration after calculation.
+ */
+static uint8_t calc_heater_dur(uint16_t dur);
+
+#ifndef BME680_FLOAT_POINT_COMPENSATION
+
+/*!
+ * @brief This internal API is used to calculate the temperature value.
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] temp_adc	:Contains the temperature ADC value .
+ *
+ * @return uint32_t calculated temperature.
+ */
+static int16_t calc_temperature(uint32_t temp_adc, struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the pressure value.
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] pres_adc	:Contains the pressure ADC value .
+ *
+ * @return uint32_t calculated pressure.
+ */
+static uint32_t calc_pressure(uint32_t pres_adc, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the humidity value.
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] hum_adc	:Contains the humidity ADC value.
+ *
+ * @return uint32_t calculated humidity.
+ */
+static uint32_t calc_humidity(uint16_t hum_adc, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the Gas Resistance value.
+ *
+ * @param[in] dev		:Structure instance of bme680_dev.
+ * @param[in] gas_res_adc	:Contains the Gas Resistance ADC value.
+ * @param[in] gas_range		:Contains the range of gas values.
+ *
+ * @return uint32_t calculated gas resistance.
+ */
+static uint32_t calc_gas_resistance(uint16_t gas_res_adc, uint8_t gas_range, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the Heat Resistance value.
+ *
+ * @param[in] dev	: Structure instance of bme680_dev
+ * @param[in] temp	: Contains the target temperature value.
+ *
+ * @return uint8_t calculated heater resistance.
+ */
+static uint8_t calc_heater_res(uint16_t temp, const struct bme680_dev *dev);
+
+#else
+/*!
+ * @brief This internal API is used to calculate the
+ * temperature value value in float format
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] temp_adc	:Contains the temperature ADC value .
+ *
+ * @return Calculated temperature in float
+ */
+static float calc_temperature(uint32_t temp_adc, struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the
+ * pressure value value in float format
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] pres_adc	:Contains the pressure ADC value .
+ *
+ * @return Calculated pressure in float.
+ */
+static float calc_pressure(uint32_t pres_adc, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the
+ * humidity value value in float format
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] hum_adc	:Contains the humidity ADC value.
+ *
+ * @return Calculated humidity in float.
+ */
+static float calc_humidity(uint16_t hum_adc, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the
+ * gas resistance value value in float format
+ *
+ * @param[in] dev		:Structure instance of bme680_dev.
+ * @param[in] gas_res_adc	:Contains the Gas Resistance ADC value.
+ * @param[in] gas_range		:Contains the range of gas values.
+ *
+ * @return Calculated gas resistance in float.
+ */
+static float calc_gas_resistance(uint16_t gas_res_adc, uint8_t gas_range, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the
+ * heater resistance value in float format
+ *
+ * @param[in] temp	: Contains the target temperature value.
+ * @param[in] dev	: Structure instance of bme680_dev.
+ *
+ * @return Calculated heater resistance in float.
+ */
+static float calc_heater_res(uint16_t temp, const struct bme680_dev *dev);
+
+#endif
+
+/*!
+ * @brief This internal API is used to calculate the field data of sensor.
+ *
+ * @param[out] data :Structure instance to hold the data
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ *  @return int8_t result of the field data from sensor.
+ */
+static int8_t read_field_data(struct bme680_field_data *data, struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to set the memory page
+ * based on register address.
+ *
+ * The value of memory page
+ *  value  | Description
+ * --------|--------------
+ *   0     | BME680_PAGE0_SPI
+ *   1     | BME680_PAGE1_SPI
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] reg_addr	:Contains the register address array.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t set_mem_page(uint8_t reg_addr, struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to get the memory page based
+ * on register address.
+ *
+ * The value of memory page
+ *  value  | Description
+ * --------|--------------
+ *   0     | BME680_PAGE0_SPI
+ *   1     | BME680_PAGE1_SPI
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t get_mem_page(struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to validate the device pointer for
+ * null conditions.
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t null_ptr_check(const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to check the boundary
+ * conditions.
+ *
+ * @param[in] value	:pointer to the value.
+ * @param[in] min	:minimum value.
+ * @param[in] max	:maximum value.
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t boundary_check(uint8_t *value, uint8_t min, uint8_t max, struct bme680_dev *dev);
+
+/****************** Global Function Definitions *******************************/
+/*!
+ *@brief This API is the entry point.
+ *It reads the chip-id and calibration data from the sensor.
+ */
+int8_t bme680_init(struct bme680_dev *dev)
+{
+	int8_t rslt;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		/* Soft reset to restore it to default values*/
+		rslt = bme680_soft_reset(dev);
+		if (rslt == BME680_OK) {
+			rslt = bme680_get_regs(BME680_CHIP_ID_ADDR, &dev->chip_id, 1, dev);
+			if (rslt == BME680_OK) {
+				if (dev->chip_id == BME680_CHIP_ID) {
+					/* Get the Calibration data */
+					rslt = get_calib_data(dev);
+				} else {
+					rslt = BME680_E_DEV_NOT_FOUND;
+				}
+			}
+		}
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API reads the data from the given register address of the sensor.
+ */
+int8_t bme680_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint16_t len, struct bme680_dev *dev)
+{
+	int8_t rslt;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if (dev->intf == BME680_SPI_INTF) {
+			/* Set the memory page */
+			rslt = set_mem_page(reg_addr, dev);
+			if (rslt == BME680_OK)
+				reg_addr = reg_addr | BME680_SPI_RD_MSK;
+		}
+		dev->com_rslt = dev->read(dev->dev_id, reg_addr, reg_data, len);
+		if (dev->com_rslt != 0)
+			rslt = BME680_E_COM_FAIL;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API writes the given data to the register address
+ * of the sensor.
+ */
+int8_t bme680_set_regs(const uint8_t *reg_addr, const uint8_t *reg_data, uint8_t len, struct bme680_dev *dev)
+{
+	int8_t rslt;
+	/* Length of the temporary buffer is 2*(length of register)*/
+	uint8_t tmp_buff[BME680_TMP_BUFFER_LENGTH] = { 0 };
+	uint16_t index;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if ((len > 0) && (len < BME680_TMP_BUFFER_LENGTH / 2)) {
+			/* Interleave the 2 arrays */
+			for (index = 0; index < len; index++) {
+				if (dev->intf == BME680_SPI_INTF) {
+					/* Set the memory page */
+					rslt = set_mem_page(reg_addr[index], dev);
+					tmp_buff[(2 * index)] = reg_addr[index] & BME680_SPI_WR_MSK;
+				} else {
+					tmp_buff[(2 * index)] = reg_addr[index];
+				}
+				tmp_buff[(2 * index) + 1] = reg_data[index];
+			}
+			/* Write the interleaved array */
+			if (rslt == BME680_OK) {
+				dev->com_rslt = dev->write(dev->dev_id, tmp_buff[0], &tmp_buff[1], (2 * len) - 1);
+				if (dev->com_rslt != 0)
+					rslt = BME680_E_COM_FAIL;
+			}
+		} else {
+			rslt = BME680_E_INVALID_LENGTH;
+		}
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API performs the soft reset of the sensor.
+ */
+int8_t bme680_soft_reset(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t reg_addr = BME680_SOFT_RESET_ADDR;
+	/* 0xb6 is the soft reset command */
+	uint8_t soft_rst_cmd = BME680_SOFT_RESET_CMD;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if (dev->intf == BME680_SPI_INTF)
+			rslt = get_mem_page(dev);
+
+		/* Reset the device */
+		if (rslt == BME680_OK) {
+			rslt = bme680_set_regs(&reg_addr, &soft_rst_cmd, 1, dev);
+			/* Wait for 5ms */
+			dev->delay_ms(BME680_RESET_PERIOD);
+
+			if (rslt == BME680_OK) {
+				/* After reset get the memory page */
+				if (dev->intf == BME680_SPI_INTF)
+					rslt = get_mem_page(dev);
+			}
+		}
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API is used to set the oversampling, filter and T,P,H, gas selection
+ * settings in the sensor.
+ */
+int8_t bme680_set_sensor_settings(uint16_t desired_settings, struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t reg_addr;
+	uint8_t data = 0;
+	uint8_t count = 0;
+	uint8_t reg_array[BME680_REG_BUFFER_LENGTH] = { 0 };
+	uint8_t data_array[BME680_REG_BUFFER_LENGTH] = { 0 };
+	uint8_t intended_power_mode = dev->power_mode; /* Save intended power mode */
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if (desired_settings & BME680_GAS_MEAS_SEL)
+			rslt = set_gas_config(dev);
+
+		dev->power_mode = BME680_SLEEP_MODE;
+		if (rslt == BME680_OK)
+			rslt = bme680_set_sensor_mode(dev);
+
+		/* Selecting the filter */
+		if (desired_settings & BME680_FILTER_SEL) {
+			rslt = boundary_check(&dev->tph_sett.filter, BME680_FILTER_SIZE_0, BME680_FILTER_SIZE_127, dev);
+			reg_addr = BME680_CONF_ODR_FILT_ADDR;
+
+			if (rslt == BME680_OK)
+				rslt = bme680_get_regs(reg_addr, &data, 1, dev);
+
+			if (desired_settings & BME680_FILTER_SEL)
+				data = BME680_SET_BITS(data, BME680_FILTER, dev->tph_sett.filter);
+
+			reg_array[count] = reg_addr; /* Append configuration */
+			data_array[count] = data;
+			count++;
+		}
+
+		/* Selecting heater control for the sensor */
+		if (desired_settings & BME680_HCNTRL_SEL) {
+			rslt = boundary_check(&dev->gas_sett.heatr_ctrl, BME680_ENABLE_HEATER,
+				BME680_DISABLE_HEATER, dev);
+			reg_addr = BME680_CONF_HEAT_CTRL_ADDR;
+
+			if (rslt == BME680_OK)
+				rslt = bme680_get_regs(reg_addr, &data, 1, dev);
+			data = BME680_SET_BITS_POS_0(data, BME680_HCTRL, dev->gas_sett.heatr_ctrl);
+
+			reg_array[count] = reg_addr; /* Append configuration */
+			data_array[count] = data;
+			count++;
+		}
+
+		/* Selecting heater T,P oversampling for the sensor */
+		if (desired_settings & (BME680_OST_SEL | BME680_OSP_SEL)) {
+			rslt = boundary_check(&dev->tph_sett.os_temp, BME680_OS_NONE, BME680_OS_16X, dev);
+			reg_addr = BME680_CONF_T_P_MODE_ADDR;
+
+			if (rslt == BME680_OK)
+				rslt = bme680_get_regs(reg_addr, &data, 1, dev);
+
+			if (desired_settings & BME680_OST_SEL)
+				data = BME680_SET_BITS(data, BME680_OST, dev->tph_sett.os_temp);
+
+			if (desired_settings & BME680_OSP_SEL)
+				data = BME680_SET_BITS(data, BME680_OSP, dev->tph_sett.os_pres);
+
+			reg_array[count] = reg_addr;
+			data_array[count] = data;
+			count++;
+		}
+
+		/* Selecting humidity oversampling for the sensor */
+		if (desired_settings & BME680_OSH_SEL) {
+			rslt = boundary_check(&dev->tph_sett.os_hum, BME680_OS_NONE, BME680_OS_16X, dev);
+			reg_addr = BME680_CONF_OS_H_ADDR;
+
+			if (rslt == BME680_OK)
+				rslt = bme680_get_regs(reg_addr, &data, 1, dev);
+			data = BME680_SET_BITS_POS_0(data, BME680_OSH, dev->tph_sett.os_hum);
+
+			reg_array[count] = reg_addr; /* Append configuration */
+			data_array[count] = data;
+			count++;
+		}
+
+		/* Selecting the runGas and NB conversion settings for the sensor */
+		if (desired_settings & (BME680_RUN_GAS_SEL | BME680_NBCONV_SEL)) {
+			rslt = boundary_check(&dev->gas_sett.run_gas, BME680_RUN_GAS_DISABLE,
+				BME680_RUN_GAS_ENABLE, dev);
+			if (rslt == BME680_OK) {
+				/* Validate boundary conditions */
+				rslt = boundary_check(&dev->gas_sett.nb_conv, BME680_NBCONV_MIN,
+					BME680_NBCONV_MAX, dev);
+			}
+
+			reg_addr = BME680_CONF_ODR_RUN_GAS_NBC_ADDR;
+
+			if (rslt == BME680_OK)
+				rslt = bme680_get_regs(reg_addr, &data, 1, dev);
+
+			if (desired_settings & BME680_RUN_GAS_SEL)
+				data = BME680_SET_BITS(data, BME680_RUN_GAS, dev->gas_sett.run_gas);
+
+			if (desired_settings & BME680_NBCONV_SEL)
+				data = BME680_SET_BITS_POS_0(data, BME680_NBCONV, dev->gas_sett.nb_conv);
+
+			reg_array[count] = reg_addr; /* Append configuration */
+			data_array[count] = data;
+			count++;
+		}
+
+		if (rslt == BME680_OK)
+			rslt = bme680_set_regs(reg_array, data_array, count, dev);
+
+		/* Restore previous intended power mode */
+		dev->power_mode = intended_power_mode;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API is used to get the oversampling, filter and T,P,H, gas selection
+ * settings in the sensor.
+ */
+int8_t bme680_get_sensor_settings(uint16_t desired_settings, struct bme680_dev *dev)
+{
+	int8_t rslt;
+	/* starting address of the register array for burst read*/
+	uint8_t reg_addr = BME680_CONF_HEAT_CTRL_ADDR;
+	uint8_t data_array[BME680_REG_BUFFER_LENGTH] = { 0 };
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		rslt = bme680_get_regs(reg_addr, data_array, BME680_REG_BUFFER_LENGTH, dev);
+
+		if (rslt == BME680_OK) {
+			if (desired_settings & BME680_GAS_MEAS_SEL)
+				rslt = get_gas_config(dev);
+
+			/* get the T,P,H ,Filter,ODR settings here */
+			if (desired_settings & BME680_FILTER_SEL)
+				dev->tph_sett.filter = BME680_GET_BITS(data_array[BME680_REG_FILTER_INDEX],
+					BME680_FILTER);
+
+			if (desired_settings & (BME680_OST_SEL | BME680_OSP_SEL)) {
+				dev->tph_sett.os_temp = BME680_GET_BITS(data_array[BME680_REG_TEMP_INDEX], BME680_OST);
+				dev->tph_sett.os_pres = BME680_GET_BITS(data_array[BME680_REG_PRES_INDEX], BME680_OSP);
+			}
+
+			if (desired_settings & BME680_OSH_SEL)
+				dev->tph_sett.os_hum = BME680_GET_BITS_POS_0(data_array[BME680_REG_HUM_INDEX],
+					BME680_OSH);
+
+			/* get the gas related settings */
+			if (desired_settings & BME680_HCNTRL_SEL)
+				dev->gas_sett.heatr_ctrl = BME680_GET_BITS_POS_0(data_array[BME680_REG_HCTRL_INDEX],
+					BME680_HCTRL);
+
+			if (desired_settings & (BME680_RUN_GAS_SEL | BME680_NBCONV_SEL)) {
+				dev->gas_sett.nb_conv = BME680_GET_BITS_POS_0(data_array[BME680_REG_NBCONV_INDEX],
+					BME680_NBCONV);
+				dev->gas_sett.run_gas = BME680_GET_BITS(data_array[BME680_REG_RUN_GAS_INDEX],
+					BME680_RUN_GAS);
+			}
+		}
+	} else {
+		rslt = BME680_E_NULL_PTR;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API is used to set the power mode of the sensor.
+ */
+int8_t bme680_set_sensor_mode(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t tmp_pow_mode;
+	uint8_t pow_mode = 0;
+	uint8_t reg_addr = BME680_CONF_T_P_MODE_ADDR;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		/* Call repeatedly until in sleep */
+		do {
+			rslt = bme680_get_regs(BME680_CONF_T_P_MODE_ADDR, &tmp_pow_mode, 1, dev);
+			if (rslt == BME680_OK) {
+				/* Put to sleep before changing mode */
+				pow_mode = (tmp_pow_mode & BME680_MODE_MSK);
+
+				if (pow_mode != BME680_SLEEP_MODE) {
+					tmp_pow_mode = tmp_pow_mode & (~BME680_MODE_MSK); /* Set to sleep */
+					rslt = bme680_set_regs(&reg_addr, &tmp_pow_mode, 1, dev);
+					dev->delay_ms(BME680_POLL_PERIOD_MS);
+				}
+			}
+		} while (pow_mode != BME680_SLEEP_MODE);
+
+		/* Already in sleep */
+		if (dev->power_mode != BME680_SLEEP_MODE) {
+			tmp_pow_mode = (tmp_pow_mode & ~BME680_MODE_MSK) | (dev->power_mode & BME680_MODE_MSK);
+			if (rslt == BME680_OK)
+				rslt = bme680_set_regs(&reg_addr, &tmp_pow_mode, 1, dev);
+		}
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API is used to get the power mode of the sensor.
+ */
+int8_t bme680_get_sensor_mode(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t mode;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		rslt = bme680_get_regs(BME680_CONF_T_P_MODE_ADDR, &mode, 1, dev);
+		/* Masking the other register bit info*/
+		dev->power_mode = mode & BME680_MODE_MSK;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API is used to set the profile duration of the sensor.
+ */
+void bme680_set_profile_dur(uint16_t duration, struct bme680_dev *dev)
+{
+	uint32_t tph_dur; /* Calculate in us */
+	uint32_t meas_cycles;
+	uint8_t os_to_meas_cycles[6] = {0, 1, 2, 4, 8, 16};
+
+	meas_cycles = os_to_meas_cycles[dev->tph_sett.os_temp];
+	meas_cycles += os_to_meas_cycles[dev->tph_sett.os_pres];
+	meas_cycles += os_to_meas_cycles[dev->tph_sett.os_hum];
+
+	/* TPH measurement duration */
+	tph_dur = meas_cycles * UINT32_C(1963);
+	tph_dur += UINT32_C(477 * 4); /* TPH switching duration */
+	tph_dur += UINT32_C(477 * 5); /* Gas measurement duration */
+	tph_dur += UINT32_C(500); /* Get it to the closest whole number.*/
+	tph_dur /= UINT32_C(1000); /* Convert to ms */
+
+	tph_dur += UINT32_C(1); /* Wake up duration of 1ms */
+	/* The remaining time should be used for heating */
+	dev->gas_sett.heatr_dur = duration - (uint16_t) tph_dur;
+}
+
+/*!
+ * @brief This API is used to get the profile duration of the sensor.
+ */
+void bme680_get_profile_dur(uint16_t *duration, const struct bme680_dev *dev)
+{
+	uint32_t tph_dur; /* Calculate in us */
+	uint32_t meas_cycles;
+	uint8_t os_to_meas_cycles[6] = {0, 1, 2, 4, 8, 16};
+
+	meas_cycles = os_to_meas_cycles[dev->tph_sett.os_temp];
+	meas_cycles += os_to_meas_cycles[dev->tph_sett.os_pres];
+	meas_cycles += os_to_meas_cycles[dev->tph_sett.os_hum];
+
+	/* TPH measurement duration */
+	tph_dur = meas_cycles * UINT32_C(1963);
+	tph_dur += UINT32_C(477 * 4); /* TPH switching duration */
+	tph_dur += UINT32_C(477 * 5); /* Gas measurement duration */
+	tph_dur += UINT32_C(500); /* Get it to the closest whole number.*/
+	tph_dur /= UINT32_C(1000); /* Convert to ms */
+
+	tph_dur += UINT32_C(1); /* Wake up duration of 1ms */
+
+	*duration = (uint16_t) tph_dur;
+
+	/* Get the gas duration only when the run gas is enabled */
+	if (dev->gas_sett.run_gas) {
+		/* The remaining time should be used for heating */
+		*duration += dev->gas_sett.heatr_dur;
+	}
+}
+
+/*!
+ * @brief This API reads the pressure, temperature and humidity and gas data
+ * from the sensor, compensates the data and store it in the bme680_data
+ * structure instance passed by the user.
+ */
+int8_t bme680_get_sensor_data(struct bme680_field_data *data, struct bme680_dev *dev)
+{
+	int8_t rslt;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		/* Reading the sensor data in forced mode only */
+		rslt = read_field_data(data, dev);
+		if (rslt == BME680_OK) {
+			if (data->status & BME680_NEW_DATA_MSK)
+				dev->new_fields = 1;
+			else
+				dev->new_fields = 0;
+		}
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to read the calibrated data from the sensor.
+ */
+static int8_t get_calib_data(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t coeff_array[BME680_COEFF_SIZE] = { 0 };
+	uint8_t temp_var = 0; /* Temporary variable */
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		rslt = bme680_get_regs(BME680_COEFF_ADDR1, coeff_array, BME680_COEFF_ADDR1_LEN, dev);
+		/* Append the second half in the same array */
+		if (rslt == BME680_OK)
+			rslt = bme680_get_regs(BME680_COEFF_ADDR2, &coeff_array[BME680_COEFF_ADDR1_LEN]
+			, BME680_COEFF_ADDR2_LEN, dev);
+
+		/* Temperature related coefficients */
+		dev->calib.par_t1 = (uint16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_T1_MSB_REG],
+			coeff_array[BME680_T1_LSB_REG]));
+		dev->calib.par_t2 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_T2_MSB_REG],
+			coeff_array[BME680_T2_LSB_REG]));
+		dev->calib.par_t3 = (int8_t) (coeff_array[BME680_T3_REG]);
+
+		/* Pressure related coefficients */
+		dev->calib.par_p1 = (uint16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P1_MSB_REG],
+			coeff_array[BME680_P1_LSB_REG]));
+		dev->calib.par_p2 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P2_MSB_REG],
+			coeff_array[BME680_P2_LSB_REG]));
+		dev->calib.par_p3 = (int8_t) coeff_array[BME680_P3_REG];
+		dev->calib.par_p4 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P4_MSB_REG],
+			coeff_array[BME680_P4_LSB_REG]));
+		dev->calib.par_p5 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P5_MSB_REG],
+			coeff_array[BME680_P5_LSB_REG]));
+		dev->calib.par_p6 = (int8_t) (coeff_array[BME680_P6_REG]);
+		dev->calib.par_p7 = (int8_t) (coeff_array[BME680_P7_REG]);
+		dev->calib.par_p8 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P8_MSB_REG],
+			coeff_array[BME680_P8_LSB_REG]));
+		dev->calib.par_p9 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P9_MSB_REG],
+			coeff_array[BME680_P9_LSB_REG]));
+		dev->calib.par_p10 = (uint8_t) (coeff_array[BME680_P10_REG]);
+
+		/* Humidity related coefficients */
+		dev->calib.par_h1 = (uint16_t) (((uint16_t) coeff_array[BME680_H1_MSB_REG] << BME680_HUM_REG_SHIFT_VAL)
+			| (coeff_array[BME680_H1_LSB_REG] & BME680_BIT_H1_DATA_MSK));
+		dev->calib.par_h2 = (uint16_t) (((uint16_t) coeff_array[BME680_H2_MSB_REG] << BME680_HUM_REG_SHIFT_VAL)
+			| ((coeff_array[BME680_H2_LSB_REG]) >> BME680_HUM_REG_SHIFT_VAL));
+		dev->calib.par_h3 = (int8_t) coeff_array[BME680_H3_REG];
+		dev->calib.par_h4 = (int8_t) coeff_array[BME680_H4_REG];
+		dev->calib.par_h5 = (int8_t) coeff_array[BME680_H5_REG];
+		dev->calib.par_h6 = (uint8_t) coeff_array[BME680_H6_REG];
+		dev->calib.par_h7 = (int8_t) coeff_array[BME680_H7_REG];
+
+		/* Gas heater related coefficients */
+		dev->calib.par_gh1 = (int8_t) coeff_array[BME680_GH1_REG];
+		dev->calib.par_gh2 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_GH2_MSB_REG],
+			coeff_array[BME680_GH2_LSB_REG]));
+		dev->calib.par_gh3 = (int8_t) coeff_array[BME680_GH3_REG];
+
+		/* Other coefficients */
+		if (rslt == BME680_OK) {
+			rslt = bme680_get_regs(BME680_ADDR_RES_HEAT_RANGE_ADDR, &temp_var, 1, dev);
+
+			dev->calib.res_heat_range = ((temp_var & BME680_RHRANGE_MSK) / 16);
+			if (rslt == BME680_OK) {
+				rslt = bme680_get_regs(BME680_ADDR_RES_HEAT_VAL_ADDR, &temp_var, 1, dev);
+
+				dev->calib.res_heat_val = (int8_t) temp_var;
+				if (rslt == BME680_OK)
+					rslt = bme680_get_regs(BME680_ADDR_RANGE_SW_ERR_ADDR, &temp_var, 1, dev);
+			}
+		}
+		dev->calib.range_sw_err = ((int8_t) temp_var & (int8_t) BME680_RSERROR_MSK) / 16;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to set the gas configuration of the sensor.
+ */
+static int8_t set_gas_config(struct bme680_dev *dev)
+{
+	int8_t rslt;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+
+		uint8_t reg_addr[2] = {0};
+		uint8_t reg_data[2] = {0};
+
+		if (dev->power_mode == BME680_FORCED_MODE) {
+			reg_addr[0] = BME680_RES_HEAT0_ADDR;
+			reg_data[0] = calc_heater_res(dev->gas_sett.heatr_temp, dev);
+			reg_addr[1] = BME680_GAS_WAIT0_ADDR;
+			reg_data[1] = calc_heater_dur(dev->gas_sett.heatr_dur);
+			dev->gas_sett.nb_conv = 0;
+		} else {
+			rslt = BME680_W_DEFINE_PWR_MODE;
+		}
+		if (rslt == BME680_OK)
+			rslt = bme680_set_regs(reg_addr, reg_data, 2, dev);
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to get the gas configuration of the sensor.
+ * @note heatr_temp and heatr_dur values are currently register data
+ * and not the actual values set
+ */
+static int8_t get_gas_config(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	/* starting address of the register array for burst read*/
+	uint8_t reg_addr1 = BME680_ADDR_SENS_CONF_START;
+	uint8_t reg_addr2 = BME680_ADDR_GAS_CONF_START;
+	uint8_t reg_data = 0;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if (BME680_SPI_INTF == dev->intf) {
+			/* Memory page switch the SPI address*/
+			rslt = set_mem_page(reg_addr1, dev);
+		}
+
+		if (rslt == BME680_OK) {
+			rslt = bme680_get_regs(reg_addr1, &reg_data, 1, dev);
+			if (rslt == BME680_OK) {
+				dev->gas_sett.heatr_temp = reg_data;
+				rslt = bme680_get_regs(reg_addr2, &reg_data, 1, dev);
+				if (rslt == BME680_OK) {
+					/* Heating duration register value */
+					dev->gas_sett.heatr_dur = reg_data;
+				}
+			}
+		}
+	}
+
+	return rslt;
+}
+
+#ifndef BME680_FLOAT_POINT_COMPENSATION
+
+/*!
+ * @brief This internal API is used to calculate the temperature value.
+ */
+static int16_t calc_temperature(uint32_t temp_adc, struct bme680_dev *dev)
+{
+	int64_t var1;
+	int64_t var2;
+	int64_t var3;
+	int16_t calc_temp;
+
+	var1 = ((int32_t) temp_adc >> 3) - ((int32_t) dev->calib.par_t1 << 1);
+	var2 = (var1 * (int32_t) dev->calib.par_t2) >> 11;
+	var3 = ((var1 >> 1) * (var1 >> 1)) >> 12;
+	var3 = ((var3) * ((int32_t) dev->calib.par_t3 << 4)) >> 14;
+	dev->calib.t_fine = (int32_t) (var2 + var3);
+	calc_temp = (int16_t) (((dev->calib.t_fine * 5) + 128) >> 8);
+
+	return calc_temp;
+}
+
+/*!
+ * @brief This internal API is used to calculate the pressure value.
+ */
+static uint32_t calc_pressure(uint32_t pres_adc, const struct bme680_dev *dev)
+{
+	int32_t var1;
+	int32_t var2;
+	int32_t var3;
+	int32_t pressure_comp;
+
+	var1 = (((int32_t)dev->calib.t_fine) >> 1) - 64000;
+	var2 = ((((var1 >> 2) * (var1 >> 2)) >> 11) *
+		(int32_t)dev->calib.par_p6) >> 2;
+	var2 = var2 + ((var1 * (int32_t)dev->calib.par_p5) << 1);
+	var2 = (var2 >> 2) + ((int32_t)dev->calib.par_p4 << 16);
+	var1 = (((((var1 >> 2) * (var1 >> 2)) >> 13) *
+		((int32_t)dev->calib.par_p3 << 5)) >> 3) +
+		(((int32_t)dev->calib.par_p2 * var1) >> 1);
+	var1 = var1 >> 18;
+	var1 = ((32768 + var1) * (int32_t)dev->calib.par_p1) >> 15;
+	pressure_comp = 1048576 - pres_adc;
+	pressure_comp = (int32_t)((pressure_comp - (var2 >> 12)) * ((uint32_t)3125));
+	if (pressure_comp >= BME680_MAX_OVERFLOW_VAL)
+		pressure_comp = ((pressure_comp / var1) << 1);
+	else
+		pressure_comp = ((pressure_comp << 1) / var1);
+	var1 = ((int32_t)dev->calib.par_p9 * (int32_t)(((pressure_comp >> 3) *
+		(pressure_comp >> 3)) >> 13)) >> 12;
+	var2 = ((int32_t)(pressure_comp >> 2) *
+		(int32_t)dev->calib.par_p8) >> 13;
+	var3 = ((int32_t)(pressure_comp >> 8) * (int32_t)(pressure_comp >> 8) *
+		(int32_t)(pressure_comp >> 8) *
+		(int32_t)dev->calib.par_p10) >> 17;
+
+	pressure_comp = (int32_t)(pressure_comp) + ((var1 + var2 + var3 +
+		((int32_t)dev->calib.par_p7 << 7)) >> 4);
+
+	return (uint32_t)pressure_comp;
+
+}
+
+/*!
+ * @brief This internal API is used to calculate the humidity value.
+ */
+static uint32_t calc_humidity(uint16_t hum_adc, const struct bme680_dev *dev)
+{
+	int32_t var1;
+	int32_t var2;
+	int32_t var3;
+	int32_t var4;
+	int32_t var5;
+	int32_t var6;
+	int32_t temp_scaled;
+	int32_t calc_hum;
+
+	temp_scaled = (((int32_t) dev->calib.t_fine * 5) + 128) >> 8;
+	var1 = (int32_t) (hum_adc - ((int32_t) ((int32_t) dev->calib.par_h1 * 16)))
+		- (((temp_scaled * (int32_t) dev->calib.par_h3) / ((int32_t) 100)) >> 1);
+	var2 = ((int32_t) dev->calib.par_h2
+		* (((temp_scaled * (int32_t) dev->calib.par_h4) / ((int32_t) 100))
+			+ (((temp_scaled * ((temp_scaled * (int32_t) dev->calib.par_h5) / ((int32_t) 100))) >> 6)
+				/ ((int32_t) 100)) + (int32_t) (1 << 14))) >> 10;
+	var3 = var1 * var2;
+	var4 = (int32_t) dev->calib.par_h6 << 7;
+	var4 = ((var4) + ((temp_scaled * (int32_t) dev->calib.par_h7) / ((int32_t) 100))) >> 4;
+	var5 = ((var3 >> 14) * (var3 >> 14)) >> 10;
+	var6 = (var4 * var5) >> 1;
+	calc_hum = (((var3 + var6) >> 10) * ((int32_t) 1000)) >> 12;
+
+	if (calc_hum > 100000) /* Cap at 100%rH */
+		calc_hum = 100000;
+	else if (calc_hum < 0)
+		calc_hum = 0;
+
+	return (uint32_t) calc_hum;
+}
+
+/*!
+ * @brief This internal API is used to calculate the Gas Resistance value.
+ */
+static uint32_t calc_gas_resistance(uint16_t gas_res_adc, uint8_t gas_range, const struct bme680_dev *dev)
+{
+	int64_t var1;
+	uint64_t var2;
+	int64_t var3;
+	uint32_t calc_gas_res;
+	/**Look up table 1 for the possible gas range values */
+	uint32_t lookupTable1[16] = { UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647),
+		UINT32_C(2147483647), UINT32_C(2126008810), UINT32_C(2147483647), UINT32_C(2130303777),
+		UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2143188679), UINT32_C(2136746228),
+		UINT32_C(2147483647), UINT32_C(2126008810), UINT32_C(2147483647), UINT32_C(2147483647) };
+	/**Look up table 2 for the possible gas range values */
+	uint32_t lookupTable2[16] = { UINT32_C(4096000000), UINT32_C(2048000000), UINT32_C(1024000000), UINT32_C(512000000),
+		UINT32_C(255744255), UINT32_C(127110228), UINT32_C(64000000), UINT32_C(32258064), UINT32_C(16016016),
+		UINT32_C(8000000), UINT32_C(4000000), UINT32_C(2000000), UINT32_C(1000000), UINT32_C(500000),
+		UINT32_C(250000), UINT32_C(125000) };
+
+	var1 = (int64_t) ((1340 + (5 * (int64_t) dev->calib.range_sw_err)) *
+		((int64_t) lookupTable1[gas_range])) >> 16;
+	var2 = (((int64_t) ((int64_t) gas_res_adc << 15) - (int64_t) (16777216)) + var1);
+	var3 = (((int64_t) lookupTable2[gas_range] * (int64_t) var1) >> 9);
+	calc_gas_res = (uint32_t) ((var3 + ((int64_t) var2 >> 1)) / (int64_t) var2);
+
+	return calc_gas_res;
+}
+
+/*!
+ * @brief This internal API is used to calculate the Heat Resistance value.
+ */
+static uint8_t calc_heater_res(uint16_t temp, const struct bme680_dev *dev)
+{
+	uint8_t heatr_res;
+	int32_t var1;
+	int32_t var2;
+	int32_t var3;
+	int32_t var4;
+	int32_t var5;
+	int32_t heatr_res_x100;
+
+	if (temp > 400) /* Cap temperature */
+		temp = 400;
+
+	var1 = (((int32_t) dev->amb_temp * dev->calib.par_gh3) / 1000) * 256;
+	var2 = (dev->calib.par_gh1 + 784) * (((((dev->calib.par_gh2 + 154009) * temp * 5) / 100) + 3276800) / 10);
+	var3 = var1 + (var2 / 2);
+	var4 = (var3 / (dev->calib.res_heat_range + 4));
+	var5 = (131 * dev->calib.res_heat_val) + 65536;
+	heatr_res_x100 = (int32_t) (((var4 / var5) - 250) * 34);
+	heatr_res = (uint8_t) ((heatr_res_x100 + 50) / 100);
+
+	return heatr_res;
+}
+
+#else
+
+
+/*!
+ * @brief This internal API is used to calculate the
+ * temperature value in float format
+ */
+static float calc_temperature(uint32_t temp_adc, struct bme680_dev *dev)
+{
+	float var1 = 0;
+	float var2 = 0;
+	float calc_temp = 0;
+
+	/* calculate var1 data */
+	var1  = ((((float)temp_adc / 16384.0f) - ((float)dev->calib.par_t1 / 1024.0f))
+			* ((float)dev->calib.par_t2));
+
+	/* calculate var2 data */
+	var2  = (((((float)temp_adc / 131072.0f) - ((float)dev->calib.par_t1 / 8192.0f)) *
+		(((float)temp_adc / 131072.0f) - ((float)dev->calib.par_t1 / 8192.0f))) *
+		((float)dev->calib.par_t3 * 16.0f));
+
+	/* t_fine value*/
+	dev->calib.t_fine = (var1 + var2);
+
+	/* compensated temperature data*/
+	calc_temp  = ((dev->calib.t_fine) / 5120.0f);
+
+	return calc_temp;
+}
+
+/*!
+ * @brief This internal API is used to calculate the
+ * pressure value in float format
+ */
+static float calc_pressure(uint32_t pres_adc, const struct bme680_dev *dev)
+{
+	float var1 = 0;
+	float var2 = 0;
+	float var3 = 0;
+	float calc_pres = 0;
+
+	var1 = (((float)dev->calib.t_fine / 2.0f) - 64000.0f);
+	var2 = var1 * var1 * (((float)dev->calib.par_p6) / (131072.0f));
+	var2 = var2 + (var1 * ((float)dev->calib.par_p5) * 2.0f);
+	var2 = (var2 / 4.0f) + (((float)dev->calib.par_p4) * 65536.0f);
+	var1 = (((((float)dev->calib.par_p3 * var1 * var1) / 16384.0f)
+		+ ((float)dev->calib.par_p2 * var1)) / 524288.0f);
+	var1 = ((1.0f + (var1 / 32768.0f)) * ((float)dev->calib.par_p1));
+	calc_pres = (1048576.0f - ((float)pres_adc));
+
+	/* Avoid exception caused by division by zero */
+	if ((int)var1 != 0) {
+		calc_pres = (((calc_pres - (var2 / 4096.0f)) * 6250.0f) / var1);
+		var1 = (((float)dev->calib.par_p9) * calc_pres * calc_pres) / 2147483648.0f;
+		var2 = calc_pres * (((float)dev->calib.par_p8) / 32768.0f);
+		var3 = ((calc_pres / 256.0f) * (calc_pres / 256.0f) * (calc_pres / 256.0f)
+			* (dev->calib.par_p10 / 131072.0f));
+		calc_pres = (calc_pres + (var1 + var2 + var3 + ((float)dev->calib.par_p7 * 128.0f)) / 16.0f);
+	} else {
+		calc_pres = 0;
+	}
+
+	return calc_pres;
+}
+
+/*!
+ * @brief This internal API is used to calculate the
+ * humidity value in float format
+ */
+static float calc_humidity(uint16_t hum_adc, const struct bme680_dev *dev)
+{
+	float calc_hum = 0;
+	float var1 = 0;
+	float var2 = 0;
+	float var3 = 0;
+	float var4 = 0;
+	float temp_comp;
+
+	/* compensated temperature data*/
+	temp_comp  = ((dev->calib.t_fine) / 5120.0f);
+
+	var1 = (float)((float)hum_adc) - (((float)dev->calib.par_h1 * 16.0f) + (((float)dev->calib.par_h3 / 2.0f)
+		* temp_comp));
+
+	var2 = var1 * ((float)(((float) dev->calib.par_h2 / 262144.0f) * (1.0f + (((float)dev->calib.par_h4 / 16384.0f)
+		* temp_comp) + (((float)dev->calib.par_h5 / 1048576.0f) * temp_comp * temp_comp))));
+
+	var3 = (float) dev->calib.par_h6 / 16384.0f;
+
+	var4 = (float) dev->calib.par_h7 / 2097152.0f;
+
+	calc_hum = var2 + ((var3 + (var4 * temp_comp)) * var2 * var2);
+
+	if (calc_hum > 100.0f)
+		calc_hum = 100.0f;
+	else if (calc_hum < 0.0f)
+		calc_hum = 0.0f;
+
+	return calc_hum;
+}
+
+/*!
+ * @brief This internal API is used to calculate the
+ * gas resistance value in float format
+ */
+static float calc_gas_resistance(uint16_t gas_res_adc, uint8_t gas_range, const struct bme680_dev *dev)
+{
+	float calc_gas_res;
+	float var1 = 0;
+	float var2 = 0;
+	float var3 = 0;
+
+	const float lookup_k1_range[16] = {
+	0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, -0.8,
+	0.0, 0.0, -0.2, -0.5, 0.0, -1.0, 0.0, 0.0};
+	const float lookup_k2_range[16] = {
+	0.0, 0.0, 0.0, 0.0, 0.1, 0.7, 0.0, -0.8,
+	-0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+	var1 = (1340.0f + (5.0f * dev->calib.range_sw_err));
+	var2 = (var1) * (1.0f + lookup_k1_range[gas_range]/100.0f);
+	var3 = 1.0f + (lookup_k2_range[gas_range]/100.0f);
+
+	calc_gas_res = 1.0f / (float)(var3 * (0.000000125f) * (float)(1 << gas_range) * (((((float)gas_res_adc)
+		- 512.0f)/var2) + 1.0f));
+
+	return calc_gas_res;
+}
+
+/*!
+ * @brief This internal API is used to calculate the
+ * heater resistance value in float format
+ */
+static float calc_heater_res(uint16_t temp, const struct bme680_dev *dev)
+{
+	float var1 = 0;
+	float var2 = 0;
+	float var3 = 0;
+	float var4 = 0;
+	float var5 = 0;
+	float res_heat = 0;
+
+	if (temp > 400) /* Cap temperature */
+		temp = 400;
+
+	var1 = (((float)dev->calib.par_gh1 / (16.0f)) + 49.0f);
+	var2 = ((((float)dev->calib.par_gh2 / (32768.0f)) * (0.0005f)) + 0.00235f);
+	var3 = ((float)dev->calib.par_gh3 / (1024.0f));
+	var4 = (var1 * (1.0f + (var2 * (float)temp)));
+	var5 = (var4 + (var3 * (float)dev->amb_temp));
+	res_heat = (uint8_t)(3.4f * ((var5 * (4 / (4 + (float)dev->calib.res_heat_range)) *
+		(1/(1 + ((float) dev->calib.res_heat_val * 0.002f)))) - 25));
+
+	return res_heat;
+}
+
+#endif
+
+/*!
+ * @brief This internal API is used to calculate the Heat duration value.
+ */
+static uint8_t calc_heater_dur(uint16_t dur)
+{
+	uint8_t factor = 0;
+	uint8_t durval;
+
+	if (dur >= 0xfc0) {
+		durval = 0xff; /* Max duration*/
+	} else {
+		while (dur > 0x3F) {
+			dur = dur / 4;
+			factor += 1;
+		}
+		durval = (uint8_t) (dur + (factor * 64));
+	}
+
+	return durval;
+}
+
+/*!
+ * @brief This internal API is used to calculate the field data of sensor.
+ */
+static int8_t read_field_data(struct bme680_field_data *data, struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t buff[BME680_FIELD_LENGTH] = { 0 };
+	uint8_t gas_range;
+	uint32_t adc_temp;
+	uint32_t adc_pres;
+	uint16_t adc_hum;
+	uint16_t adc_gas_res;
+	uint8_t tries = 10;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	do {
+		if (rslt == BME680_OK) {
+			rslt = bme680_get_regs(((uint8_t) (BME680_FIELD0_ADDR)), buff, (uint16_t) BME680_FIELD_LENGTH,
+				dev);
+
+			data->status = buff[0] & BME680_NEW_DATA_MSK;
+			data->gas_index = buff[0] & BME680_GAS_INDEX_MSK;
+			data->meas_index = buff[1];
+
+			/* read the raw data from the sensor */
+			adc_pres = (uint32_t) (((uint32_t) buff[2] * 4096) | ((uint32_t) buff[3] * 16)
+				| ((uint32_t) buff[4] / 16));
+			adc_temp = (uint32_t) (((uint32_t) buff[5] * 4096) | ((uint32_t) buff[6] * 16)
+				| ((uint32_t) buff[7] / 16));
+			adc_hum = (uint16_t) (((uint32_t) buff[8] * 256) | (uint32_t) buff[9]);
+			adc_gas_res = (uint16_t) ((uint32_t) buff[13] * 4 | (((uint32_t) buff[14]) / 64));
+			gas_range = buff[14] & BME680_GAS_RANGE_MSK;
+
+			data->status |= buff[14] & BME680_GASM_VALID_MSK;
+			data->status |= buff[14] & BME680_HEAT_STAB_MSK;
+
+			if (data->status & BME680_NEW_DATA_MSK) {
+				data->temperature = calc_temperature(adc_temp, dev);
+				data->pressure = calc_pressure(adc_pres, dev);
+				data->humidity = calc_humidity(adc_hum, dev);
+				data->gas_resistance = calc_gas_resistance(adc_gas_res, gas_range, dev);
+				break;
+			}
+			/* Delay to poll the data */
+			dev->delay_ms(BME680_POLL_PERIOD_MS);
+		}
+		tries--;
+	} while (tries);
+
+	if (!tries)
+		rslt = BME680_W_NO_NEW_DATA;
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to set the memory page based on register address.
+ */
+static int8_t set_mem_page(uint8_t reg_addr, struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t reg;
+	uint8_t mem_page;
+
+	/* Check for null pointers in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if (reg_addr > 0x7f)
+			mem_page = BME680_MEM_PAGE1;
+		else
+			mem_page = BME680_MEM_PAGE0;
+
+		if (mem_page != dev->mem_page) {
+			dev->mem_page = mem_page;
+
+			dev->com_rslt = dev->read(dev->dev_id, BME680_MEM_PAGE_ADDR | BME680_SPI_RD_MSK, &reg, 1);
+			if (dev->com_rslt != 0)
+				rslt = BME680_E_COM_FAIL;
+
+			if (rslt == BME680_OK) {
+				reg = reg & (~BME680_MEM_PAGE_MSK);
+				reg = reg | (dev->mem_page & BME680_MEM_PAGE_MSK);
+
+				dev->com_rslt = dev->write(dev->dev_id, BME680_MEM_PAGE_ADDR & BME680_SPI_WR_MSK,
+					&reg, 1);
+				if (dev->com_rslt != 0)
+					rslt = BME680_E_COM_FAIL;
+			}
+		}
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to get the memory page based on register address.
+ */
+static int8_t get_mem_page(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t reg;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		dev->com_rslt = dev->read(dev->dev_id, BME680_MEM_PAGE_ADDR | BME680_SPI_RD_MSK, &reg, 1);
+		if (dev->com_rslt != 0)
+			rslt = BME680_E_COM_FAIL;
+		else
+			dev->mem_page = reg & BME680_MEM_PAGE_MSK;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to validate the boundary
+ * conditions.
+ */
+static int8_t boundary_check(uint8_t *value, uint8_t min, uint8_t max, struct bme680_dev *dev)
+{
+	int8_t rslt = BME680_OK;
+
+	if (value != NULL) {
+		/* Check if value is below minimum value */
+		if (*value < min) {
+			/* Auto correct the invalid value to minimum value */
+			*value = min;
+			dev->info_msg |= BME680_I_MIN_CORRECTION;
+		}
+		/* Check if value is above maximum value */
+		if (*value > max) {
+			/* Auto correct the invalid value to maximum value */
+			*value = max;
+			dev->info_msg |= BME680_I_MAX_CORRECTION;
+		}
+	} else {
+		rslt = BME680_E_NULL_PTR;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to validate the device structure pointer for
+ * null conditions.
+ */
+static int8_t null_ptr_check(const struct bme680_dev *dev)
+{
+	int8_t rslt;
+
+	if ((dev == NULL) || (dev->read == NULL) || (dev->write == NULL) || (dev->delay_ms == NULL)) {
+		/* Device structure pointer is not valid */
+		rslt = BME680_E_NULL_PTR;
+	} else {
+		/* Device structure is fine */
+		rslt = BME680_OK;
+	}
+
+	return rslt;
+}

--- a/device/sensor/drv/drv_gr_baro_temp_hum_bosch_bme680/bme680.h
+++ b/device/sensor/drv/drv_gr_baro_temp_hum_bosch_bme680/bme680.h
@@ -1,0 +1,225 @@
+/**
+ * Copyright (C) 2017 - 2018 Bosch Sensortec GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of the copyright holder nor the names of the
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES(INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+ *
+ * The information provided is believed to be accurate and reliable.
+ * The copyright holder assumes no responsibility
+ * for the consequences of use
+ * of such information nor for any infringement of patents or
+ * other rights of third parties which may result from its use.
+ * No license is granted by implication or otherwise under any patent or
+ * patent rights of the copyright holder.
+ *
+ * @file	bme680.h
+ * @date	19 Jun 2018
+ * @version	3.5.9
+ * @brief
+ *
+ */
+/*! @file bme680.h
+ @brief Sensor driver for BME680 sensor */
+/*!
+ * @defgroup BME680 SENSOR API
+ * @{*/
+#ifndef BME680_H_
+#define BME680_H_
+
+/*! CPP guard */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Header includes */
+#include "bme680_defs.h"
+
+/* function prototype declarations */
+/*!
+ *  @brief This API is the entry point.
+ *  It reads the chip-id and calibration data from the sensor.
+ *
+ *  @param[in,out] dev : Structure instance of bme680_dev
+ *
+ *  @return Result of API execution status
+ *  @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+int8_t bme680_init(struct bme680_dev *dev);
+
+/*!
+ * @brief This API writes the given data to the register address
+ * of the sensor.
+ *
+ * @param[in] reg_addr : Register address from where the data to be written.
+ * @param[in] reg_data : Pointer to data buffer which is to be written
+ * in the sensor.
+ * @param[in] len : No of bytes of data to write..
+ * @param[in] dev : Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+int8_t bme680_set_regs(const uint8_t *reg_addr, const uint8_t *reg_data, uint8_t len, struct bme680_dev *dev);
+
+/*!
+ * @brief This API reads the data from the given register address of the sensor.
+ *
+ * @param[in] reg_addr : Register address from where the data to be read
+ * @param[out] reg_data : Pointer to data buffer to store the read data.
+ * @param[in] len : No of bytes of data to be read.
+ * @param[in] dev : Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+int8_t bme680_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint16_t len, struct bme680_dev *dev);
+
+/*!
+ * @brief This API performs the soft reset of the sensor.
+ *
+ * @param[in] dev : Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error.
+ */
+int8_t bme680_soft_reset(struct bme680_dev *dev);
+
+/*!
+ * @brief This API is used to set the power mode of the sensor.
+ *
+ * @param[in] dev : Structure instance of bme680_dev
+ * @note : Pass the value to bme680_dev.power_mode structure variable.
+ *
+ *  value	|	mode
+ * -------------|------------------
+ *	0x00	|	BME680_SLEEP_MODE
+ *	0x01	|	BME680_FORCED_MODE
+ *
+ * * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+int8_t bme680_set_sensor_mode(struct bme680_dev *dev);
+
+/*!
+ * @brief This API is used to get the power mode of the sensor.
+ *
+ * @param[in] dev : Structure instance of bme680_dev
+ * @note : bme680_dev.power_mode structure variable hold the power mode.
+ *
+ *  value	|	mode
+ * ---------|------------------
+ *	0x00	|	BME680_SLEEP_MODE
+ *	0x01	|	BME680_FORCED_MODE
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+int8_t bme680_get_sensor_mode(struct bme680_dev *dev);
+
+/*!
+ * @brief This API is used to set the profile duration of the sensor.
+ *
+ * @param[in] dev	   : Structure instance of bme680_dev.
+ * @param[in] duration : Duration of the measurement in ms.
+ *
+ * @return Nothing
+ */
+void bme680_set_profile_dur(uint16_t duration, struct bme680_dev *dev);
+
+/*!
+ * @brief This API is used to get the profile duration of the sensor.
+ *
+ * @param[in] dev	   : Structure instance of bme680_dev.
+ * @param[in] duration : Duration of the measurement in ms.
+ *
+ * @return Nothing
+ */
+void bme680_get_profile_dur(uint16_t *duration, const struct bme680_dev *dev);
+
+/*!
+ * @brief This API reads the pressure, temperature and humidity and gas data
+ * from the sensor, compensates the data and store it in the bme680_data
+ * structure instance passed by the user.
+ *
+ * @param[out] data: Structure instance to hold the data.
+ * @param[in] dev : Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+int8_t bme680_get_sensor_data(struct bme680_field_data *data, struct bme680_dev *dev);
+
+/*!
+ * @brief This API is used to set the oversampling, filter and T,P,H, gas selection
+ * settings in the sensor.
+ *
+ * @param[in] dev : Structure instance of bme680_dev.
+ * @param[in] desired_settings : Variable used to select the settings which
+ * are to be set in the sensor.
+ *
+ *	 Macros	                   |  Functionality
+ *---------------------------------|----------------------------------------------
+ *	BME680_OST_SEL             |    To set temperature oversampling.
+ *	BME680_OSP_SEL             |    To set pressure oversampling.
+ *	BME680_OSH_SEL             |    To set humidity oversampling.
+ *	BME680_GAS_MEAS_SEL        |    To set gas measurement setting.
+ *	BME680_FILTER_SEL          |    To set filter setting.
+ *	BME680_HCNTRL_SEL          |    To set humidity control setting.
+ *	BME680_RUN_GAS_SEL         |    To set run gas setting.
+ *	BME680_NBCONV_SEL          |    To set NB conversion setting.
+ *	BME680_GAS_SENSOR_SEL      |    To set all gas sensor related settings
+ *
+ * @note : Below are the macros to be used by the user for selecting the
+ * desired settings. User can do OR operation of these macros for configuring
+ * multiple settings.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error.
+ */
+int8_t bme680_set_sensor_settings(uint16_t desired_settings, struct bme680_dev *dev);
+
+/*!
+ * @brief This API is used to get the oversampling, filter and T,P,H, gas selection
+ * settings in the sensor.
+ *
+ * @param[in] dev : Structure instance of bme680_dev.
+ * @param[in] desired_settings : Variable used to select the settings which
+ * are to be get from the sensor.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error.
+ */
+int8_t bme680_get_sensor_settings(uint16_t desired_settings, struct bme680_dev *dev);
+#ifdef __cplusplus
+}
+#endif /* End of CPP guard */
+#endif /* BME680_H_ */
+/** @}*/

--- a/device/sensor/drv/drv_gr_baro_temp_hum_bosch_bme680/bme680_defs.h
+++ b/device/sensor/drv/drv_gr_baro_temp_hum_bosch_bme680/bme680_defs.h
@@ -1,0 +1,545 @@
+/**
+ * Copyright (C) 2017 - 2018 Bosch Sensortec GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of the copyright holder nor the names of the
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES(INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+ *
+ * The information provided is believed to be accurate and reliable.
+ * The copyright holder assumes no responsibility
+ * for the consequences of use
+ * of such information nor for any infringement of patents or
+ * other rights of third parties which may result from its use.
+ * No license is granted by implication or otherwise under any patent or
+ * patent rights of the copyright holder.
+ *
+ * @file	bme680_defs.h
+ * @date	19 Jun 2018
+ * @version	3.5.9
+ * @brief
+ *
+ */
+
+/*! @file bme680_defs.h
+ @brief Sensor driver for BME680 sensor */
+/*!
+ * @defgroup BME680 SENSOR API
+ * @brief
+ * @{*/
+#ifndef BME680_DEFS_H_
+#define BME680_DEFS_H_
+
+/********************************************************/
+/* header includes */
+#ifdef __KERNEL__
+#include <linux/types.h>
+#include <linux/kernel.h>
+#else
+#include <stdint.h>
+#include <stddef.h>
+#endif
+
+/******************************************************************************/
+/*! @name		Common macros					      */
+/******************************************************************************/
+
+#if !defined(UINT8_C) && !defined(INT8_C)
+#define INT8_C(x)       S8_C(x)
+#define UINT8_C(x)      U8_C(x)
+#endif
+
+#if !defined(UINT16_C) && !defined(INT16_C)
+#define INT16_C(x)      S16_C(x)
+#define UINT16_C(x)     U16_C(x)
+#endif
+
+#if !defined(INT32_C) && !defined(UINT32_C)
+#define INT32_C(x)      S32_C(x)
+#define UINT32_C(x)     U32_C(x)
+#endif
+
+#if !defined(INT64_C) && !defined(UINT64_C)
+#define INT64_C(x)      S64_C(x)
+#define UINT64_C(x)     U64_C(x)
+#endif
+
+/**@}*/
+
+/**\name C standard macros */
+#ifndef NULL
+#ifdef __cplusplus
+#define NULL   0
+#else
+#define NULL   ((void *) 0)
+#endif
+#endif
+
+/** BME680 configuration macros */
+/** Enable or un-comment the macro to provide floating point data output */
+#ifndef BME680_FLOAT_POINT_COMPENSATION
+/* #define BME680_FLOAT_POINT_COMPENSATION */
+#endif
+
+/** BME680 General config */
+#define BME680_POLL_PERIOD_MS		UINT8_C(10)
+
+/** BME680 I2C addresses */
+#define BME680_I2C_ADDR_PRIMARY		UINT8_C(0x76)
+#define BME680_I2C_ADDR_SECONDARY	UINT8_C(0x77)
+
+/** BME680 unique chip identifier */
+#define BME680_CHIP_ID  UINT8_C(0x61)
+
+/** BME680 coefficients related defines */
+#define BME680_COEFF_SIZE		UINT8_C(41)
+#define BME680_COEFF_ADDR1_LEN		UINT8_C(25)
+#define BME680_COEFF_ADDR2_LEN		UINT8_C(16)
+
+/** BME680 field_x related defines */
+#define BME680_FIELD_LENGTH		UINT8_C(15)
+#define BME680_FIELD_ADDR_OFFSET	UINT8_C(17)
+
+/** Soft reset command */
+#define BME680_SOFT_RESET_CMD   UINT8_C(0xb6)
+
+/** Error code definitions */
+#define BME680_OK		INT8_C(0)
+/* Errors */
+#define BME680_E_NULL_PTR		    INT8_C(-1)
+#define BME680_E_COM_FAIL		    INT8_C(-2)
+#define BME680_E_DEV_NOT_FOUND		INT8_C(-3)
+#define BME680_E_INVALID_LENGTH		INT8_C(-4)
+
+/* Warnings */
+#define BME680_W_DEFINE_PWR_MODE	INT8_C(1)
+#define BME680_W_NO_NEW_DATA        INT8_C(2)
+
+/* Info's */
+#define BME680_I_MIN_CORRECTION		UINT8_C(1)
+#define BME680_I_MAX_CORRECTION		UINT8_C(2)
+
+/** Register map */
+/** Other coefficient's address */
+#define BME680_ADDR_RES_HEAT_VAL_ADDR	UINT8_C(0x00)
+#define BME680_ADDR_RES_HEAT_RANGE_ADDR	UINT8_C(0x02)
+#define BME680_ADDR_RANGE_SW_ERR_ADDR	UINT8_C(0x04)
+#define BME680_ADDR_SENS_CONF_START	UINT8_C(0x5A)
+#define BME680_ADDR_GAS_CONF_START	UINT8_C(0x64)
+
+/** Field settings */
+#define BME680_FIELD0_ADDR		UINT8_C(0x1d)
+
+/** Heater settings */
+#define BME680_RES_HEAT0_ADDR		UINT8_C(0x5a)
+#define BME680_GAS_WAIT0_ADDR		UINT8_C(0x64)
+
+/** Sensor configuration registers */
+#define BME680_CONF_HEAT_CTRL_ADDR		UINT8_C(0x70)
+#define BME680_CONF_ODR_RUN_GAS_NBC_ADDR	UINT8_C(0x71)
+#define BME680_CONF_OS_H_ADDR			UINT8_C(0x72)
+#define BME680_MEM_PAGE_ADDR			UINT8_C(0xf3)
+#define BME680_CONF_T_P_MODE_ADDR		UINT8_C(0x74)
+#define BME680_CONF_ODR_FILT_ADDR		UINT8_C(0x75)
+
+/** Coefficient's address */
+#define BME680_COEFF_ADDR1	UINT8_C(0x89)
+#define BME680_COEFF_ADDR2	UINT8_C(0xe1)
+
+/** Chip identifier */
+#define BME680_CHIP_ID_ADDR	UINT8_C(0xd0)
+
+/** Soft reset register */
+#define BME680_SOFT_RESET_ADDR		UINT8_C(0xe0)
+
+/** Heater control settings */
+#define BME680_ENABLE_HEATER		UINT8_C(0x00)
+#define BME680_DISABLE_HEATER		UINT8_C(0x08)
+
+/** Gas measurement settings */
+#define BME680_DISABLE_GAS_MEAS		UINT8_C(0x00)
+#define BME680_ENABLE_GAS_MEAS		UINT8_C(0x01)
+
+/** Over-sampling settings */
+#define BME680_OS_NONE		UINT8_C(0)
+#define BME680_OS_1X		UINT8_C(1)
+#define BME680_OS_2X		UINT8_C(2)
+#define BME680_OS_4X		UINT8_C(3)
+#define BME680_OS_8X		UINT8_C(4)
+#define BME680_OS_16X		UINT8_C(5)
+
+/** IIR filter settings */
+#define BME680_FILTER_SIZE_0	UINT8_C(0)
+#define BME680_FILTER_SIZE_1	UINT8_C(1)
+#define BME680_FILTER_SIZE_3	UINT8_C(2)
+#define BME680_FILTER_SIZE_7	UINT8_C(3)
+#define BME680_FILTER_SIZE_15	UINT8_C(4)
+#define BME680_FILTER_SIZE_31	UINT8_C(5)
+#define BME680_FILTER_SIZE_63	UINT8_C(6)
+#define BME680_FILTER_SIZE_127	UINT8_C(7)
+
+/** Power mode settings */
+#define BME680_SLEEP_MODE	UINT8_C(0)
+#define BME680_FORCED_MODE	UINT8_C(1)
+
+/** Delay related macro declaration */
+#define BME680_RESET_PERIOD	UINT32_C(10)
+
+/** SPI memory page settings */
+#define BME680_MEM_PAGE0	UINT8_C(0x10)
+#define BME680_MEM_PAGE1	UINT8_C(0x00)
+
+/** Ambient humidity shift value for compensation */
+#define BME680_HUM_REG_SHIFT_VAL	UINT8_C(4)
+
+/** Run gas enable and disable settings */
+#define BME680_RUN_GAS_DISABLE	UINT8_C(0)
+#define BME680_RUN_GAS_ENABLE	UINT8_C(1)
+
+/** Buffer length macro declaration */
+#define BME680_TMP_BUFFER_LENGTH	UINT8_C(40)
+#define BME680_REG_BUFFER_LENGTH	UINT8_C(6)
+#define BME680_FIELD_DATA_LENGTH	UINT8_C(3)
+#define BME680_GAS_REG_BUF_LENGTH	UINT8_C(20)
+
+/** Settings selector */
+#define BME680_OST_SEL			UINT16_C(1)
+#define BME680_OSP_SEL			UINT16_C(2)
+#define BME680_OSH_SEL			UINT16_C(4)
+#define BME680_GAS_MEAS_SEL		UINT16_C(8)
+#define BME680_FILTER_SEL		UINT16_C(16)
+#define BME680_HCNTRL_SEL		UINT16_C(32)
+#define BME680_RUN_GAS_SEL		UINT16_C(64)
+#define BME680_NBCONV_SEL		UINT16_C(128)
+#define BME680_GAS_SENSOR_SEL		(BME680_GAS_MEAS_SEL | BME680_RUN_GAS_SEL | BME680_NBCONV_SEL)
+
+/** Number of conversion settings*/
+#define BME680_NBCONV_MIN		UINT8_C(0)
+#define BME680_NBCONV_MAX		UINT8_C(10)
+
+/** Mask definitions */
+#define BME680_GAS_MEAS_MSK	UINT8_C(0x30)
+#define BME680_NBCONV_MSK	UINT8_C(0X0F)
+#define BME680_FILTER_MSK	UINT8_C(0X1C)
+#define BME680_OST_MSK		UINT8_C(0XE0)
+#define BME680_OSP_MSK		UINT8_C(0X1C)
+#define BME680_OSH_MSK		UINT8_C(0X07)
+#define BME680_HCTRL_MSK	UINT8_C(0x08)
+#define BME680_RUN_GAS_MSK	UINT8_C(0x10)
+#define BME680_MODE_MSK		UINT8_C(0x03)
+#define BME680_RHRANGE_MSK	UINT8_C(0x30)
+#define BME680_RSERROR_MSK	UINT8_C(0xf0)
+#define BME680_NEW_DATA_MSK	UINT8_C(0x80)
+#define BME680_GAS_INDEX_MSK	UINT8_C(0x0f)
+#define BME680_GAS_RANGE_MSK	UINT8_C(0x0f)
+#define BME680_GASM_VALID_MSK	UINT8_C(0x20)
+#define BME680_HEAT_STAB_MSK	UINT8_C(0x10)
+#define BME680_MEM_PAGE_MSK	UINT8_C(0x10)
+#define BME680_SPI_RD_MSK	UINT8_C(0x80)
+#define BME680_SPI_WR_MSK	UINT8_C(0x7f)
+#define	BME680_BIT_H1_DATA_MSK	UINT8_C(0x0F)
+
+/** Bit position definitions for sensor settings */
+#define BME680_GAS_MEAS_POS	UINT8_C(4)
+#define BME680_FILTER_POS	UINT8_C(2)
+#define BME680_OST_POS		UINT8_C(5)
+#define BME680_OSP_POS		UINT8_C(2)
+#define BME680_RUN_GAS_POS	UINT8_C(4)
+
+/** Array Index to Field data mapping for Calibration Data*/
+#define BME680_T2_LSB_REG	(1)
+#define BME680_T2_MSB_REG	(2)
+#define BME680_T3_REG		(3)
+#define BME680_P1_LSB_REG	(5)
+#define BME680_P1_MSB_REG	(6)
+#define BME680_P2_LSB_REG	(7)
+#define BME680_P2_MSB_REG	(8)
+#define BME680_P3_REG		(9)
+#define BME680_P4_LSB_REG	(11)
+#define BME680_P4_MSB_REG	(12)
+#define BME680_P5_LSB_REG	(13)
+#define BME680_P5_MSB_REG	(14)
+#define BME680_P7_REG		(15)
+#define BME680_P6_REG		(16)
+#define BME680_P8_LSB_REG	(19)
+#define BME680_P8_MSB_REG	(20)
+#define BME680_P9_LSB_REG	(21)
+#define BME680_P9_MSB_REG	(22)
+#define BME680_P10_REG		(23)
+#define BME680_H2_MSB_REG	(25)
+#define BME680_H2_LSB_REG	(26)
+#define BME680_H1_LSB_REG	(26)
+#define BME680_H1_MSB_REG	(27)
+#define BME680_H3_REG		(28)
+#define BME680_H4_REG		(29)
+#define BME680_H5_REG		(30)
+#define BME680_H6_REG		(31)
+#define BME680_H7_REG		(32)
+#define BME680_T1_LSB_REG	(33)
+#define BME680_T1_MSB_REG	(34)
+#define BME680_GH2_LSB_REG	(35)
+#define BME680_GH2_MSB_REG	(36)
+#define BME680_GH1_REG		(37)
+#define BME680_GH3_REG		(38)
+
+/** BME680 register buffer index settings*/
+#define BME680_REG_FILTER_INDEX		UINT8_C(5)
+#define BME680_REG_TEMP_INDEX		UINT8_C(4)
+#define BME680_REG_PRES_INDEX		UINT8_C(4)
+#define BME680_REG_HUM_INDEX		UINT8_C(2)
+#define BME680_REG_NBCONV_INDEX		UINT8_C(1)
+#define BME680_REG_RUN_GAS_INDEX	UINT8_C(1)
+#define BME680_REG_HCTRL_INDEX		UINT8_C(0)
+
+/** BME680 pressure calculation macros */
+/*! This max value is used to provide precedence to multiplication or division
+ * in pressure compensation equation to achieve least loss of precision and
+ * avoiding overflows.
+ * i.e Comparing value, BME680_MAX_OVERFLOW_VAL = INT32_C(1 << 30)
+ */
+#define BME680_MAX_OVERFLOW_VAL      INT32_C(0x40000000)
+
+/** Macro to combine two 8 bit data's to form a 16 bit data */
+#define BME680_CONCAT_BYTES(msb, lsb)	(((uint16_t)msb << 8) | (uint16_t)lsb)
+
+/** Macro to SET and GET BITS of a register */
+#define BME680_SET_BITS(reg_data, bitname, data) \
+		((reg_data & ~(bitname##_MSK)) | \
+		((data << bitname##_POS) & bitname##_MSK))
+#define BME680_GET_BITS(reg_data, bitname)	((reg_data & (bitname##_MSK)) >> \
+	(bitname##_POS))
+
+/** Macro variant to handle the bitname position if it is zero */
+#define BME680_SET_BITS_POS_0(reg_data, bitname, data) \
+				((reg_data & ~(bitname##_MSK)) | \
+				(data & bitname##_MSK))
+#define BME680_GET_BITS_POS_0(reg_data, bitname)  (reg_data & (bitname##_MSK))
+
+/** Type definitions */
+/*!
+ * Generic communication function pointer
+ * @param[in] dev_id: Place holder to store the id of the device structure
+ *                    Can be used to store the index of the Chip select or
+ *                    I2C address of the device.
+ * @param[in] reg_addr:	Used to select the register the where data needs to
+ *                      be read from or written to.
+ * @param[in/out] reg_data: Data array to read/write
+ * @param[in] len: Length of the data array
+ */
+typedef int8_t (*bme680_com_fptr_t)(uint8_t dev_id, uint8_t reg_addr, uint8_t *data, uint16_t len);
+
+/*!
+ * Delay function pointer
+ * @param[in] period: Time period in milliseconds
+ */
+typedef void (*bme680_delay_fptr_t)(uint32_t period);
+
+/*!
+ * @brief Interface selection Enumerations
+ */
+enum bme680_intf {
+	/*! SPI interface */
+	BME680_SPI_INTF,
+	/*! I2C interface */
+	BME680_I2C_INTF
+};
+
+/* structure definitions */
+/*!
+ * @brief Sensor field data structure
+ */
+struct	bme680_field_data {
+	/*! Contains new_data, gasm_valid & heat_stab */
+	uint8_t status;
+	/*! The index of the heater profile used */
+	uint8_t gas_index;
+	/*! Measurement index to track order */
+	uint8_t meas_index;
+
+#ifndef BME680_FLOAT_POINT_COMPENSATION
+	/*! Temperature in degree celsius x100 */
+	int16_t temperature;
+	/*! Pressure in Pascal */
+	uint32_t pressure;
+	/*! Humidity in % relative humidity x1000 */
+	uint32_t humidity;
+	/*! Gas resistance in Ohms */
+	uint32_t gas_resistance;
+#else
+	/*! Temperature in degree celsius */
+	float temperature;
+	/*! Pressure in Pascal */
+	float pressure;
+	/*! Humidity in % relative humidity x1000 */
+	float humidity;
+	/*! Gas resistance in Ohms */
+	float gas_resistance;
+
+#endif
+
+};
+
+/*!
+ * @brief Structure to hold the Calibration data
+ */
+struct	bme680_calib_data {
+	/*! Variable to store calibrated humidity data */
+	uint16_t par_h1;
+	/*! Variable to store calibrated humidity data */
+	uint16_t par_h2;
+	/*! Variable to store calibrated humidity data */
+	int8_t par_h3;
+	/*! Variable to store calibrated humidity data */
+	int8_t par_h4;
+	/*! Variable to store calibrated humidity data */
+	int8_t par_h5;
+	/*! Variable to store calibrated humidity data */
+	uint8_t par_h6;
+	/*! Variable to store calibrated humidity data */
+	int8_t par_h7;
+	/*! Variable to store calibrated gas data */
+	int8_t par_gh1;
+	/*! Variable to store calibrated gas data */
+	int16_t par_gh2;
+	/*! Variable to store calibrated gas data */
+	int8_t par_gh3;
+	/*! Variable to store calibrated temperature data */
+	uint16_t par_t1;
+	/*! Variable to store calibrated temperature data */
+	int16_t par_t2;
+	/*! Variable to store calibrated temperature data */
+	int8_t par_t3;
+	/*! Variable to store calibrated pressure data */
+	uint16_t par_p1;
+	/*! Variable to store calibrated pressure data */
+	int16_t par_p2;
+	/*! Variable to store calibrated pressure data */
+	int8_t par_p3;
+	/*! Variable to store calibrated pressure data */
+	int16_t par_p4;
+	/*! Variable to store calibrated pressure data */
+	int16_t par_p5;
+	/*! Variable to store calibrated pressure data */
+	int8_t par_p6;
+	/*! Variable to store calibrated pressure data */
+	int8_t par_p7;
+	/*! Variable to store calibrated pressure data */
+	int16_t par_p8;
+	/*! Variable to store calibrated pressure data */
+	int16_t par_p9;
+	/*! Variable to store calibrated pressure data */
+	uint8_t par_p10;
+
+#ifndef BME680_FLOAT_POINT_COMPENSATION
+	/*! Variable to store t_fine size */
+	int32_t t_fine;
+#else
+	/*! Variable to store t_fine size */
+	float t_fine;
+#endif
+	/*! Variable to store heater resistance range */
+	uint8_t res_heat_range;
+	/*! Variable to store heater resistance value */
+	int8_t res_heat_val;
+	/*! Variable to store error range */
+	int8_t range_sw_err;
+};
+
+/*!
+ * @brief BME680 sensor settings structure which comprises of ODR,
+ * over-sampling and filter settings.
+ */
+struct	bme680_tph_sett {
+	/*! Humidity oversampling */
+	uint8_t os_hum;
+	/*! Temperature oversampling */
+	uint8_t os_temp;
+	/*! Pressure oversampling */
+	uint8_t os_pres;
+	/*! Filter coefficient */
+	uint8_t filter;
+};
+
+/*!
+ * @brief BME680 gas sensor which comprises of gas settings
+ *  and status parameters
+ */
+struct	bme680_gas_sett {
+	/*! Variable to store nb conversion */
+	uint8_t nb_conv;
+	/*! Variable to store heater control */
+	uint8_t heatr_ctrl;
+	/*! Run gas enable value */
+	uint8_t run_gas;
+	/*! Heater temperature value */
+	uint16_t heatr_temp;
+	/*! Duration profile value */
+	uint16_t heatr_dur;
+};
+
+/*!
+ * @brief BME680 device structure
+ */
+struct	bme680_dev {
+	/*! Chip Id */
+	uint8_t chip_id;
+	/*! Device Id */
+	uint8_t dev_id;
+	/*! SPI/I2C interface */
+	enum bme680_intf intf;
+	/*! Memory page used */
+	uint8_t mem_page;
+	/*! Ambient temperature in Degree C */
+	int8_t amb_temp;
+	/*! Sensor calibration data */
+	struct bme680_calib_data calib;
+	/*! Sensor settings */
+	struct bme680_tph_sett tph_sett;
+	/*! Gas Sensor settings */
+	struct bme680_gas_sett gas_sett;
+	/*! Sensor power modes */
+	uint8_t power_mode;
+	/*! New sensor fields */
+	uint8_t new_fields;
+	/*! Store the info messages */
+	uint8_t info_msg;
+	/*! Bus read function pointer */
+	bme680_com_fptr_t read;
+	/*! Bus write function pointer */
+	bme680_com_fptr_t write;
+	/*! delay function pointer */
+	bme680_delay_fptr_t delay_ms;
+	/*! Communication function result */
+	int8_t com_rslt;
+};
+
+
+
+#endif /* BME680_DEFS_H_ */
+/** @}*/
+/** @}*/

--- a/device/sensor/drv/drv_gr_baro_temp_hum_bosch_bme680/drv_gr_baro_temp_hum_bosch_bme680.c
+++ b/device/sensor/drv/drv_gr_baro_temp_hum_bosch_bme680/drv_gr_baro_temp_hum_bosch_bme680.c
@@ -1,0 +1,1912 @@
+/*
+ * Copyright (C) 2019 X-Cite SA (http://www.x-cite.io)
+ * Written by Lemmer El Assal (lemmer@x-cite.io)
+*/
+#include "bme680.h"
+#include "sensor.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <aos/aos.h>
+#include <vfs_conf.h>
+#include <vfs_err.h>
+#include <vfs_register.h>
+#include <hal/base.h>
+#include "common.h"
+#include "sensor_drv_api.h"
+#include "sensor_hal.h"
+
+#ifndef BME680_I2C_PORT
+	#define BME680_I2C_PORT 1
+#endif
+
+#ifndef BME680_DATA_READ_MIN_INTERVAL
+	#define BME680_DATA_READ_MIN_INTERVAL 1000
+#endif
+
+#ifndef BME680_I2C_FREQ
+	#define BME680_I2C_FREQ 100000
+#endif
+
+#ifndef REDTEXT
+#define REDTEXT   "\x1B[31m"
+#endif
+#ifndef GREENTEXT
+#define GREENTEXT   "\x1B[32m"
+#endif
+#ifndef RESETTEXT
+#define RESETTEXT "\x1B[0m"
+#endif
+
+#ifndef TRACE_COLOR
+#define TRACE_COLOR(color, type, fmt, ...)  \
+    do { \
+        HAL_Printf("%s%s|%03d :: [%s] ", color, __func__, __LINE__, type); \
+        HAL_Printf(fmt, ##__VA_ARGS__); \
+        HAL_Printf("%s" RESETTEXT, "\r\n"); \
+    } while(0)
+#endif
+
+#ifndef TRACE_ERROR
+#define TRACE_ERROR(fmt, ...) TRACE_COLOR(REDTEXT, "ERROR", fmt, ##__VA_ARGS__)
+#endif
+
+#ifndef TRACE_INFO
+#define TRACE_INFO(fmt, ...) TRACE_COLOR(GREENTEXT, "INFO", fmt, ##__VA_ARGS__)
+#endif
+
+static struct bme680_dev g_bme680_dev;
+static struct bme680_field_data g_bme680_data_new;
+uint16_t g_bme680_meas_period;
+uint32_t g_bme680_timeout = 1000;
+sensor_obj_t sensor_temp, sensor_humi, sensor_gr, sensor_baro;
+static uint32_t prev_update_tick = 0;
+uint32_t now_tick = 0;
+
+
+i2c_dev_t bme680_ctx = {
+    .port = BME680_I2C_PORT,
+	.config.freq = BME680_I2C_FREQ,
+	.config.address_width = I2C_MEM_ADDR_SIZE_8BIT,
+    .config.dev_addr = BME680_I2C_ADDR_PRIMARY,
+}; 
+
+static int drv_bme680_update_data()
+{
+
+    int ret = 0;
+
+    now_tick = aos_now_ms();
+    if ((now_tick - prev_update_tick >= BME680_DATA_READ_MIN_INTERVAL) || (prev_update_tick == 0)) {
+		ret = bme680_set_sensor_mode(&g_bme680_dev);
+        if(ret != BME680_OK)
+            TRACE_ERROR("[BME680] Set sensor mode failed (returned %d)", ret);
+        aos_msleep(g_bme680_meas_period * 2);
+        ret = bme680_get_sensor_data(&g_bme680_data_new, &g_bme680_dev);
+
+		if (unlikely(ret != 0))
+            return ret;
+        prev_update_tick = now_tick;
+    }
+
+    return 0;
+}
+
+
+static void drv_gr_bosch_bme680_irq_handle(void)
+{
+    /* no handle so far */
+}
+
+static int drv_gr_bosch_bme680_open(void)
+{
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+
+    return 0;
+}
+
+static int drv_gr_bosch_bme680_close(void)
+{
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+
+    return 0;
+}
+
+static int drv_gr_bosch_bme680_read(void *buf, size_t len)
+{
+    int ret = 0;
+    const size_t size = sizeof(gr_data_t);
+    gr_data_t *pdata = (gr_data_t*)buf;
+
+    if (buf == NULL){
+        return -1;
+    }
+
+    if (len < size){
+        return -1;
+    }
+    
+    ret = drv_bme680_update_data();
+    if (ret != 0)
+        return -1;
+
+    pdata->gr = g_bme680_data_new.gas_resistance;
+
+    pdata->timestamp = aos_now_ms();
+
+    return (int)size;
+}
+
+static int drv_gr_bosch_bme680_write(const void *buf, size_t len)
+{
+    (void)buf;
+    (void)len;
+    return 0;
+}
+
+
+static int drv_gr_bosch_bme680_ioctl(int cmd, unsigned long arg)
+{
+    switch (cmd) {
+        case SENSOR_IOCTL_GET_INFO:
+		{
+			/* fill the dev info here */
+			dev_sensor_info_t *info = (dev_sensor_info_t *)arg;
+			info->model = "BME680";
+			info->vendor = DEV_SENSOR_VENDOR_BOSCH;
+			info->unit = ohm;
+			break;
+		}
+        default:
+            return -1;
+    }
+
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+    return 0;
+}
+
+static void drv_baro_bosch_bme680_irq_handle(void)
+{
+    /* no handle so far */
+}
+
+static int drv_baro_bosch_bme680_open(void)
+{
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+
+    return 0;
+}
+
+static int drv_baro_bosch_bme680_close(void)
+{
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+
+    return 0;
+}
+
+static int drv_baro_bosch_bme680_read(void *buf, size_t len)
+{
+    int ret = 0;
+    const size_t size = sizeof(barometer_data_t);
+    barometer_data_t *pdata = (barometer_data_t*)buf;
+
+    if (buf == NULL){
+        return -1;
+    }
+
+    if (len < size){
+        return -1;
+    }
+    
+    ret = drv_bme680_update_data();
+    if (ret != 0)
+        return -1;
+
+    pdata->p = g_bme680_data_new.pressure;
+
+    pdata->timestamp = aos_now_ms();
+
+    return (int)size;
+}
+
+static int drv_baro_bosch_bme680_write(const void *buf, size_t len)
+{
+    (void)buf;
+    (void)len;
+    return 0;
+}
+
+
+static int drv_baro_bosch_bme680_ioctl(int cmd, unsigned long arg)
+{
+    switch (cmd) {
+        case SENSOR_IOCTL_GET_INFO: {
+			dev_sensor_info_t *info = (dev_sensor_info_t *)arg;
+			info->model = "BME680";
+			info->vendor = DEV_SENSOR_VENDOR_BOSCH;
+			info->unit = pascal;
+			break;
+		}	
+        default:
+            return -1;
+    }
+
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+    return 0;
+}
+
+static void drv_humi_bosch_bme680_irq_handle(void)
+{
+    /* no handle so far */
+}
+
+static int drv_humi_bosch_bme680_open(void)
+{
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+
+    return 0;
+}
+
+static int drv_humi_bosch_bme680_close(void)
+{
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+
+    return 0;
+}
+
+static int drv_humi_bosch_bme680_read(void *buf, size_t len)
+{
+    int ret = 0;
+    const size_t size = sizeof(humidity_data_t);
+    humidity_data_t *pdata = (humidity_data_t*)buf;
+
+    if (buf == NULL){
+        return -1;
+    }
+
+    if (len < size){
+        return -1;
+    }
+    
+    ret = drv_bme680_update_data();
+    if (ret != 0)
+        return -1;
+
+    pdata->h = g_bme680_data_new.humidity / 1000;
+
+    pdata->timestamp = aos_now_ms();
+
+    return (int)size;
+}
+
+static int drv_humi_bosch_bme680_write(const void *buf, size_t len)
+{
+    (void)buf;
+    (void)len;
+    return 0;
+}
+
+
+static int drv_humi_bosch_bme680_ioctl(int cmd, unsigned long arg)
+{
+		switch (cmd) {
+			case SENSOR_IOCTL_GET_INFO: {
+				/* fill the dev info here */
+				dev_sensor_info_t *info = (dev_sensor_info_t *)arg;
+				info->model = "BME680";
+				info->vendor = DEV_SENSOR_VENDOR_BOSCH;
+				info->unit = percentage;
+				break;
+			}
+			default:
+				return -1;
+    	}
+
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+    return 0;
+}
+
+static void drv_temp_bosch_bme680_irq_handle(void)
+{
+    /* no handle so far */
+}
+
+static int drv_temp_bosch_bme680_open(void)
+{
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+
+    return 0;
+}
+
+static int drv_temp_bosch_bme680_close(void)
+{
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+
+    return 0;
+}
+
+static int drv_temp_bosch_bme680_read(void *buf, size_t len)
+{
+    int ret = 0;
+    const size_t size = sizeof(temperature_data_t);
+    temperature_data_t *pdata = (temperature_data_t*)buf;
+    if ((buf == NULL) || (len < size))
+        return -1;
+    ret = drv_bme680_update_data();
+    if (ret != 0)
+        return -1;
+
+    pdata->t = g_bme680_data_new.temperature / 100;
+	TRACE_INFO("Temperature raw: %d", g_bme680_data_new.temperature);
+	TRACE_INFO("Temperature: %d", pdata->t);
+	
+
+    pdata->timestamp = aos_now_ms();
+
+    return (int)size;
+}
+
+static int drv_temp_bosch_bme680_write(const void *buf, size_t len)
+{
+    (void)buf;
+    (void)len;
+    return 0;
+}
+
+
+static int drv_temp_bosch_bme680_ioctl(int cmd, unsigned long arg)
+{
+    switch (cmd) {
+        case SENSOR_IOCTL_GET_INFO: {
+			dev_sensor_info_t *info = (dev_sensor_info_t *)arg;
+            info->model = "BME680";
+			info->vendor = DEV_SENSOR_VENDOR_BOSCH;
+            info->unit = dCelsius;
+        	break;
+		}
+        default:
+            return -1;
+    }
+
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+    return 0;
+}
+
+int8_t user_i2c_write(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, uint16_t len)
+{
+    return hal_i2c_mem_write(&bme680_ctx, bme680_ctx.config.dev_addr, (uint16_t) reg_addr, 1, reg_data, len, g_bme680_timeout);
+}
+
+int8_t user_i2c_read(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, uint16_t len)
+{
+    int8_t result = user_i2c_write(dev_id, reg_addr, 0, 0);
+    if(result)
+        return result;
+    result = hal_i2c_master_recv(&bme680_ctx, bme680_ctx.config.dev_addr, reg_data, len, g_bme680_timeout);
+    return result;
+}
+
+void user_delay_ms(uint32_t period)
+{
+    aos_msleep(period);
+}
+
+
+int8_t user_spi_read(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, uint16_t len)
+{
+    return -1; //return hal_spi_recv(brd_spi_dev, reg_data, len, timeout);
+}
+
+int8_t user_spi_write(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, uint16_t len)
+{
+    return -1; //return hal_spi_send(brd_spi_dev, reg_data, len, timeout);
+}
+
+int32_t drv_bme680_init(int8_t bSPInI2C){
+	int32_t rslt = 0;
+
+    if(bSPInI2C) {
+        g_bme680_dev.read = user_spi_read;
+        g_bme680_dev.write = user_spi_write;
+        g_bme680_dev.intf = BME680_SPI_INTF;
+    } else {
+        g_bme680_dev.read = user_i2c_read;
+        g_bme680_dev.write = user_i2c_write;
+        g_bme680_dev.intf = BME680_I2C_INTF;
+		rslt = hal_i2c_init(&bme680_ctx);
+    }
+    g_bme680_dev.delay_ms = user_delay_ms;
+    g_bme680_dev.amb_temp = 25;
+    g_bme680_timeout = 1000;
+
+    rslt = bme680_init(&g_bme680_dev);
+    if (BME680_OK != rslt) {
+        TRACE_ERROR("BME680 device not found (returned %d)", rslt);
+        return rslt;
+    }
+    //
+    // Configuring the sensor
+    //
+    uint8_t set_required_settings;
+
+    /* Set the temperature, pressure and humidity settings */
+    g_bme680_dev.tph_sett.os_hum = BME680_OS_2X;
+    g_bme680_dev.tph_sett.os_pres = BME680_OS_4X;
+    g_bme680_dev.tph_sett.os_temp = BME680_OS_8X;
+    g_bme680_dev.tph_sett.filter = BME680_FILTER_SIZE_3;
+
+    /* Set the remaining gas sensor settings and link the heating profile */
+    g_bme680_dev.gas_sett.run_gas = BME680_ENABLE_GAS_MEAS;
+    /* Create a ramp heat waveform in 3 steps */
+    g_bme680_dev.gas_sett.heatr_temp = 320; /* degree Celsius */
+    g_bme680_dev.gas_sett.heatr_dur = 150;  /* milliseconds */
+
+    /* Select the power mode */
+    /* Must be set before writing the sensor configuration */
+    g_bme680_dev.power_mode = BME680_FORCED_MODE;
+
+    /* Set the required sensor settings needed */
+    set_required_settings = BME680_OST_SEL | BME680_OSP_SEL | BME680_OSH_SEL | BME680_FILTER_SEL | BME680_GAS_SENSOR_SEL;
+    /* Set the desired sensor configuration */
+    rslt = bme680_set_sensor_settings(set_required_settings, &g_bme680_dev);
+    if (BME680_OK != rslt) {
+        TRACE_ERROR("[BME680] Could not set sensor settings (returned %d)", rslt);
+        return rslt;
+    }
+    rslt = bme680_set_sensor_mode(&g_bme680_dev);
+    if (BME680_OK != rslt) {
+        TRACE_ERROR("[BME680] Could not set sensor mode (returned %d)", rslt);
+        return rslt;
+    }
+    bme680_get_profile_dur(&g_bme680_meas_period, &g_bme680_dev);
+
+    memset(&sensor_temp, 0, sizeof(sensor_temp));
+	/* fill the sensor_temp obj parameters here */
+	sensor_temp.tag        = TAG_DEV_TEMP;
+	sensor_temp.path       = dev_temp_path;
+	sensor_temp.io_port    = BME680_I2C_PORT;
+	sensor_temp.open       = drv_temp_bosch_bme680_open;
+	sensor_temp.close      = drv_temp_bosch_bme680_close;
+	sensor_temp.read       = drv_temp_bosch_bme680_read;
+	sensor_temp.write      = drv_temp_bosch_bme680_write;
+	sensor_temp.ioctl      = drv_temp_bosch_bme680_ioctl;
+	sensor_temp.irq_handle = drv_temp_bosch_bme680_irq_handle;
+	rslt = sensor_create_obj(&sensor_temp);
+	if (unlikely(rslt)) {
+		return -1;
+	}
+
+	memset(&sensor_humi, 0, sizeof(sensor_humi));
+	/* fill the sensor_humi obj parameters here */
+	sensor_humi.tag        = TAG_DEV_HUMI;
+	sensor_humi.path       = dev_humi_path;
+	sensor_humi.io_port    = BME680_I2C_PORT;
+	sensor_humi.open       = drv_humi_bosch_bme680_open;
+	sensor_humi.close      = drv_humi_bosch_bme680_close;
+	sensor_humi.read       = drv_humi_bosch_bme680_read;
+	sensor_humi.write      = drv_humi_bosch_bme680_write;
+	sensor_humi.ioctl      = drv_humi_bosch_bme680_ioctl;
+	sensor_humi.irq_handle = drv_humi_bosch_bme680_irq_handle;
+	rslt = sensor_create_obj(&sensor_humi);
+	if (unlikely(rslt)) {
+		return -1;
+	}
+
+	memset(&sensor_baro, 0, sizeof(sensor_baro));
+	/* fill the sensor_baro obj parameters here */
+	sensor_baro.tag        = TAG_DEV_BARO;
+	sensor_baro.path       = dev_baro_path;
+	sensor_baro.io_port    = BME680_I2C_PORT;
+	sensor_baro.open       = drv_baro_bosch_bme680_open;
+	sensor_baro.close      = drv_baro_bosch_bme680_close;
+	sensor_baro.read       = drv_baro_bosch_bme680_read;
+	sensor_baro.write      = drv_baro_bosch_bme680_write;
+	sensor_baro.ioctl      = drv_baro_bosch_bme680_ioctl;
+	sensor_baro.irq_handle = drv_baro_bosch_bme680_irq_handle;
+	rslt = sensor_create_obj(&sensor_baro);
+	if (unlikely(rslt)) {
+		return -1;
+	}
+
+	memset(&sensor_gr, 0, sizeof(sensor_gr));
+	/* fill the sensor_gr obj parameters here */
+	sensor_gr.tag        = TAG_DEV_GR;
+	sensor_gr.path       = dev_gas_resistance_path;
+	sensor_gr.io_port    = BME680_I2C_PORT;
+	sensor_gr.open       = drv_gr_bosch_bme680_open;
+	sensor_gr.close      = drv_gr_bosch_bme680_close;
+	sensor_gr.read       = drv_gr_bosch_bme680_read;
+	sensor_gr.write      = drv_gr_bosch_bme680_write;
+	sensor_gr.ioctl      = drv_gr_bosch_bme680_ioctl;
+	sensor_gr.irq_handle = drv_gr_bosch_bme680_irq_handle;
+	rslt = sensor_create_obj(&sensor_gr);
+	if (unlikely(rslt)) {
+		return -1;
+	}
+
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+    return BME680_OK;
+
+}
+	
+/*!
+ * @brief This internal API is used to read the calibrated data from the sensor.
+ *
+ * This function is used to retrieve the calibration
+ * data from the image registers of the sensor.
+ *
+ * @note Registers 89h  to A1h for calibration data 1 to 24
+ *        from bit 0 to 7
+ * @note Registers E1h to F0h for calibration data 25 to 40
+ *        from bit 0 to 7
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status.
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t get_calib_data(struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to set the gas configuration of the sensor.
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status.
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t set_gas_config(struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to get the gas configuration of the sensor.
+ * @note heatr_temp and heatr_dur values are currently register data
+ * and not the actual values set
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status.
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t get_gas_config(struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the Heat duration value.
+ *
+ * @param[in] dur	:Value of the duration to be shared.
+ *
+ * @return uint8_t threshold duration after calculation.
+ */
+static uint8_t calc_heater_dur(uint16_t dur);
+
+#ifndef BME680_FLOAT_POINT_COMPENSATION
+
+/*!
+ * @brief This internal API is used to calculate the temperature value.
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] temp_adc	:Contains the temperature ADC value .
+ *
+ * @return uint32_t calculated temperature.
+ */
+static int16_t calc_temperature(uint32_t temp_adc, struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the pressure value.
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] pres_adc	:Contains the pressure ADC value .
+ *
+ * @return uint32_t calculated pressure.
+ */
+static uint32_t calc_pressure(uint32_t pres_adc, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the humidity value.
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] hum_adc	:Contains the humidity ADC value.
+ *
+ * @return uint32_t calculated humidity.
+ */
+static uint32_t calc_humidity(uint16_t hum_adc, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the Gas Resistance value.
+ *
+ * @param[in] dev		:Structure instance of bme680_dev.
+ * @param[in] gas_res_adc	:Contains the Gas Resistance ADC value.
+ * @param[in] gas_range		:Contains the range of gas values.
+ *
+ * @return uint32_t calculated gas resistance.
+ */
+static uint32_t calc_gas_resistance(uint16_t gas_res_adc, uint8_t gas_range, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the Heat Resistance value.
+ *
+ * @param[in] dev	: Structure instance of bme680_dev
+ * @param[in] temp	: Contains the target temperature value.
+ *
+ * @return uint8_t calculated heater resistance.
+ */
+static uint8_t calc_heater_res(uint16_t temp, const struct bme680_dev *dev);
+
+#else
+/*!
+ * @brief This internal API is used to calculate the
+ * temperature value value in float format
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] temp_adc	:Contains the temperature ADC value .
+ *
+ * @return Calculated temperature in float
+ */
+static float calc_temperature(uint32_t temp_adc, struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the
+ * pressure value value in float format
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] pres_adc	:Contains the pressure ADC value .
+ *
+ * @return Calculated pressure in float.
+ */
+static float calc_pressure(uint32_t pres_adc, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the
+ * humidity value value in float format
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] hum_adc	:Contains the humidity ADC value.
+ *
+ * @return Calculated humidity in float.
+ */
+static float calc_humidity(uint16_t hum_adc, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the
+ * gas resistance value value in float format
+ *
+ * @param[in] dev		:Structure instance of bme680_dev.
+ * @param[in] gas_res_adc	:Contains the Gas Resistance ADC value.
+ * @param[in] gas_range		:Contains the range of gas values.
+ *
+ * @return Calculated gas resistance in float.
+ */
+static float calc_gas_resistance(uint16_t gas_res_adc, uint8_t gas_range, const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to calculate the
+ * heater resistance value in float format
+ *
+ * @param[in] temp	: Contains the target temperature value.
+ * @param[in] dev	: Structure instance of bme680_dev.
+ *
+ * @return Calculated heater resistance in float.
+ */
+static float calc_heater_res(uint16_t temp, const struct bme680_dev *dev);
+
+#endif
+
+/*!
+ * @brief This internal API is used to calculate the field data of sensor.
+ *
+ * @param[out] data :Structure instance to hold the data
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ *  @return int8_t result of the field data from sensor.
+ */
+static int8_t read_field_data(struct bme680_field_data *data, struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to set the memory page
+ * based on register address.
+ *
+ * The value of memory page
+ *  value  | Description
+ * --------|--------------
+ *   0     | BME680_PAGE0_SPI
+ *   1     | BME680_PAGE1_SPI
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ * @param[in] reg_addr	:Contains the register address array.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t set_mem_page(uint8_t reg_addr, struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to get the memory page based
+ * on register address.
+ *
+ * The value of memory page
+ *  value  | Description
+ * --------|--------------
+ *   0     | BME680_PAGE0_SPI
+ *   1     | BME680_PAGE1_SPI
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t get_mem_page(struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to validate the device pointer for
+ * null conditions.
+ *
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t null_ptr_check(const struct bme680_dev *dev);
+
+/*!
+ * @brief This internal API is used to check the boundary
+ * conditions.
+ *
+ * @param[in] value	:pointer to the value.
+ * @param[in] min	:minimum value.
+ * @param[in] max	:maximum value.
+ * @param[in] dev	:Structure instance of bme680_dev.
+ *
+ * @return Result of API execution status
+ * @retval zero -> Success / +ve value -> Warning / -ve value -> Error
+ */
+static int8_t boundary_check(uint8_t *value, uint8_t min, uint8_t max, struct bme680_dev *dev);
+
+/****************** Global Function Definitions *******************************/
+/*!
+ *@brief This API is the entry point.
+ *It reads the chip-id and calibration data from the sensor.
+ */
+int8_t bme680_init(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		/* Soft reset to restore it to default values*/
+		rslt = bme680_soft_reset(dev);
+		if (rslt == BME680_OK) {
+			rslt = bme680_get_regs(BME680_CHIP_ID_ADDR, &dev->chip_id, 1, dev);
+			if (rslt == BME680_OK) {
+				TRACE_INFO("[BME680] Chip id: %02x", dev->chip_id);
+				if (dev->chip_id == BME680_CHIP_ID) {
+					rslt = get_calib_data(dev);
+				} else {
+					rslt = BME680_E_DEV_NOT_FOUND;
+				}
+			}
+		} else {
+			TRACE_ERROR("[BME680] Soft reset unsuccessful (returned %d)",rslt);
+		}
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API reads the data from the given register address of the sensor.
+ */
+int8_t bme680_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint16_t len, struct bme680_dev *dev)
+{
+	int8_t rslt;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if (dev->intf == BME680_SPI_INTF) {
+			/* Set the memory page */
+			rslt = set_mem_page(reg_addr, dev);
+			if (rslt == BME680_OK)
+				reg_addr = reg_addr | BME680_SPI_RD_MSK;
+		}
+		dev->com_rslt = dev->read(dev->dev_id, reg_addr, reg_data, len);
+		if (dev->com_rslt != 0)
+			rslt = BME680_E_COM_FAIL;
+	}
+	if(rslt != 0)
+		TRACE_ERROR("bme680_get_regs failed (addr = 0x%02x)",reg_addr);
+
+	return rslt;
+}
+
+/*!
+ * @brief This API writes the given data to the register address
+ * of the sensor.
+ */
+int8_t bme680_set_regs(const uint8_t *reg_addr, const uint8_t *reg_data, uint8_t len, struct bme680_dev *dev)
+{
+	int8_t rslt;
+	/* Length of the temporary buffer is 2*(length of register)*/
+	uint8_t tmp_buff[BME680_TMP_BUFFER_LENGTH] = { 0 };
+	uint16_t index;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if ((len > 0) && (len < BME680_TMP_BUFFER_LENGTH / 2)) {
+			/* Interleave the 2 arrays */
+			for (index = 0; index < len; index++) {
+				if (dev->intf == BME680_SPI_INTF) {
+					/* Set the memory page */
+					rslt = set_mem_page(reg_addr[index], dev);
+					tmp_buff[(2 * index)] = reg_addr[index] & BME680_SPI_WR_MSK;
+				} else {
+					tmp_buff[(2 * index)] = reg_addr[index];
+				}
+				tmp_buff[(2 * index) + 1] = reg_data[index];
+			}
+			/* Write the interleaved array */
+			if (rslt == BME680_OK) {
+				dev->com_rslt = dev->write(dev->dev_id, tmp_buff[0], &tmp_buff[1], (2 * len) - 1);
+				if (dev->com_rslt != 0)
+					rslt = BME680_E_COM_FAIL;
+			}
+		} else {
+			rslt = BME680_E_INVALID_LENGTH;
+		}
+	}
+
+	if(rslt != 0)
+		TRACE_ERROR("bme680_set_regs failed (addr = 0x%02x)",*reg_addr);
+
+	return rslt;
+}
+
+/*!
+ * @brief This API performs the soft reset of the sensor.
+ */
+int8_t bme680_soft_reset(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t reg_addr = BME680_SOFT_RESET_ADDR;
+	/* 0xb6 is the soft reset command */
+	uint8_t soft_rst_cmd = BME680_SOFT_RESET_CMD;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if (dev->intf == BME680_SPI_INTF)
+			rslt = get_mem_page(dev);
+
+		/* Reset the device */
+		if (rslt == BME680_OK) {
+			rslt = bme680_set_regs(&reg_addr, &soft_rst_cmd, 1, dev);
+			/* Wait for 5ms */
+			dev->delay_ms(BME680_RESET_PERIOD);
+
+			if (rslt == BME680_OK) {
+				/* After reset get the memory page */
+				if (dev->intf == BME680_SPI_INTF)
+					rslt = get_mem_page(dev);
+			}
+		}
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API is used to set the oversampling, filter and T,P,H, gas selection
+ * settings in the sensor.
+ */
+int8_t bme680_set_sensor_settings(uint16_t desired_settings, struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t reg_addr;
+	uint8_t data = 0;
+	uint8_t count = 0;
+	uint8_t reg_array[BME680_REG_BUFFER_LENGTH] = { 0 };
+	uint8_t data_array[BME680_REG_BUFFER_LENGTH] = { 0 };
+	uint8_t intended_power_mode = dev->power_mode; /* Save intended power mode */
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if (desired_settings & BME680_GAS_MEAS_SEL) {
+			rslt = set_gas_config(dev);
+			if(rslt != BME680_OK) {
+				TRACE_ERROR("[BME680] set_gas_config failed");
+				return rslt;
+			}
+				
+		}
+			
+		dev->power_mode = BME680_SLEEP_MODE;
+		if (rslt == BME680_OK)
+			rslt = bme680_set_sensor_mode(dev);
+		else {
+			TRACE_ERROR("[BME680] set_sensor_mode failed");
+			return rslt;
+		}
+
+		/* Selecting the filter */
+		if (desired_settings & BME680_FILTER_SEL) {
+			rslt = boundary_check(&dev->tph_sett.filter, BME680_FILTER_SIZE_0, BME680_FILTER_SIZE_127, dev);
+			reg_addr = BME680_CONF_ODR_FILT_ADDR;
+
+			if (rslt == BME680_OK)
+				rslt = bme680_get_regs(reg_addr, &data, 1, dev);
+			else {
+				TRACE_ERROR("[BME680] get_regs failed");
+				return rslt;
+			}
+				
+			if (desired_settings & BME680_FILTER_SEL)
+				data = BME680_SET_BITS(data, BME680_FILTER, dev->tph_sett.filter);
+
+			reg_array[count] = reg_addr; /* Append configuration */
+			data_array[count] = data;
+			count++;
+		}
+
+		/* Selecting heater control for the sensor */
+		if (desired_settings & BME680_HCNTRL_SEL) {
+			rslt = boundary_check(&dev->gas_sett.heatr_ctrl, BME680_ENABLE_HEATER,
+				BME680_DISABLE_HEATER, dev);
+			if(rslt != BME680_OK) {
+				TRACE_ERROR("[BME680] boundary_check failed");
+				return rslt;
+			}
+			reg_addr = BME680_CONF_HEAT_CTRL_ADDR;
+
+			if (rslt == BME680_OK)
+				rslt = bme680_get_regs(reg_addr, &data, 1, dev);
+			else {
+				TRACE_ERROR("[BME680] get_regs failed");
+				return rslt;
+			}
+			data = BME680_SET_BITS_POS_0(data, BME680_HCTRL, dev->gas_sett.heatr_ctrl);
+
+			reg_array[count] = reg_addr; /* Append configuration */
+			data_array[count] = data;
+			count++;
+		}
+
+		/* Selecting heater T,P oversampling for the sensor */
+		if (desired_settings & (BME680_OST_SEL | BME680_OSP_SEL)) {
+			rslt = boundary_check(&dev->tph_sett.os_temp, BME680_OS_NONE, BME680_OS_16X, dev);
+			reg_addr = BME680_CONF_T_P_MODE_ADDR;
+
+			if (rslt == BME680_OK)
+				rslt = bme680_get_regs(reg_addr, &data, 1, dev);
+			else {
+				TRACE_ERROR("[BME680] get_regs failed");
+				return rslt;
+
+			}
+				
+			if (desired_settings & BME680_OST_SEL)
+				data = BME680_SET_BITS(data, BME680_OST, dev->tph_sett.os_temp);
+
+			if (desired_settings & BME680_OSP_SEL)
+				data = BME680_SET_BITS(data, BME680_OSP, dev->tph_sett.os_pres);
+
+			reg_array[count] = reg_addr;
+			data_array[count] = data;
+			count++;
+		}
+
+		/* Selecting humidity oversampling for the sensor */
+		if (desired_settings & BME680_OSH_SEL) {
+			rslt = boundary_check(&dev->tph_sett.os_hum, BME680_OS_NONE, BME680_OS_16X, dev);
+			reg_addr = BME680_CONF_OS_H_ADDR;
+
+			if (rslt == BME680_OK)
+				rslt = bme680_get_regs(reg_addr, &data, 1, dev);
+			else {
+				TRACE_ERROR("[BME680] boundary_check failed");
+				return rslt;
+			}
+			data = BME680_SET_BITS_POS_0(data, BME680_OSH, dev->tph_sett.os_hum);
+
+			reg_array[count] = reg_addr; /* Append configuration */
+			data_array[count] = data;
+			count++;
+		}
+
+		/* Selecting the runGas and NB conversion settings for the sensor */
+		if (desired_settings & (BME680_RUN_GAS_SEL | BME680_NBCONV_SEL)) {
+			rslt = boundary_check(&dev->gas_sett.run_gas, BME680_RUN_GAS_DISABLE,
+				BME680_RUN_GAS_ENABLE, dev);
+			if (rslt == BME680_OK) {
+				/* Validate boundary conditions */
+				rslt = boundary_check(&dev->gas_sett.nb_conv, BME680_NBCONV_MIN,
+					BME680_NBCONV_MAX, dev);
+				if(rslt != BME680_OK) {
+					TRACE_ERROR("[BME680] boundary_check failed");
+					return rslt;
+				}
+			} else {
+				TRACE_ERROR("[BME680] boundary_check failed");
+				return rslt;
+			}
+				
+			reg_addr = BME680_CONF_ODR_RUN_GAS_NBC_ADDR;
+
+			if (rslt == BME680_OK)
+				rslt = bme680_get_regs(reg_addr, &data, 1, dev);
+			else {
+				TRACE_ERROR("[BME680] get_regs failed");
+				return rslt;
+			}
+
+			if (desired_settings & BME680_RUN_GAS_SEL)
+				data = BME680_SET_BITS(data, BME680_RUN_GAS, dev->gas_sett.run_gas);
+
+			if (desired_settings & BME680_NBCONV_SEL)
+				data = BME680_SET_BITS_POS_0(data, BME680_NBCONV, dev->gas_sett.nb_conv);
+
+			reg_array[count] = reg_addr; /* Append configuration */
+			data_array[count] = data;
+			count++;
+		}
+
+		if (rslt == BME680_OK)
+			rslt = bme680_set_regs(reg_array, data_array, count, dev);
+		else {
+			TRACE_ERROR("[BME680] set_regs failed");
+			return rslt;
+		}
+
+		/* Restore previous intended power mode */
+		dev->power_mode = intended_power_mode;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API is used to get the oversampling, filter and T,P,H, gas selection
+ * settings in the sensor.
+ */
+int8_t bme680_get_sensor_settings(uint16_t desired_settings, struct bme680_dev *dev)
+{
+	int8_t rslt;
+	/* starting address of the register array for burst read*/
+	uint8_t reg_addr = BME680_CONF_HEAT_CTRL_ADDR;
+	uint8_t data_array[BME680_REG_BUFFER_LENGTH] = { 0 };
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		rslt = bme680_get_regs(reg_addr, data_array, BME680_REG_BUFFER_LENGTH, dev);
+
+		if (rslt == BME680_OK) {
+			if (desired_settings & BME680_GAS_MEAS_SEL)
+				rslt = get_gas_config(dev);
+
+			/* get the T,P,H ,Filter,ODR settings here */
+			if (desired_settings & BME680_FILTER_SEL)
+				dev->tph_sett.filter = BME680_GET_BITS(data_array[BME680_REG_FILTER_INDEX],
+					BME680_FILTER);
+
+			if (desired_settings & (BME680_OST_SEL | BME680_OSP_SEL)) {
+				dev->tph_sett.os_temp = BME680_GET_BITS(data_array[BME680_REG_TEMP_INDEX], BME680_OST);
+				dev->tph_sett.os_pres = BME680_GET_BITS(data_array[BME680_REG_PRES_INDEX], BME680_OSP);
+			}
+
+			if (desired_settings & BME680_OSH_SEL)
+				dev->tph_sett.os_hum = BME680_GET_BITS_POS_0(data_array[BME680_REG_HUM_INDEX],
+					BME680_OSH);
+
+			/* get the gas related settings */
+			if (desired_settings & BME680_HCNTRL_SEL)
+				dev->gas_sett.heatr_ctrl = BME680_GET_BITS_POS_0(data_array[BME680_REG_HCTRL_INDEX],
+					BME680_HCTRL);
+
+			if (desired_settings & (BME680_RUN_GAS_SEL | BME680_NBCONV_SEL)) {
+				dev->gas_sett.nb_conv = BME680_GET_BITS_POS_0(data_array[BME680_REG_NBCONV_INDEX],
+					BME680_NBCONV);
+				dev->gas_sett.run_gas = BME680_GET_BITS(data_array[BME680_REG_RUN_GAS_INDEX],
+					BME680_RUN_GAS);
+			}
+		}
+	} else {
+		rslt = BME680_E_NULL_PTR;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API is used to set the power mode of the sensor.
+ */
+int8_t bme680_set_sensor_mode(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t tmp_pow_mode;
+	uint8_t pow_mode = 0;
+	uint8_t reg_addr = BME680_CONF_T_P_MODE_ADDR;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		/* Call repeatedly until in sleep */
+		do {
+			rslt = bme680_get_regs(BME680_CONF_T_P_MODE_ADDR, &tmp_pow_mode, 1, dev);
+			if (rslt == BME680_OK) {
+				/* Put to sleep before changing mode */
+				pow_mode = (tmp_pow_mode & BME680_MODE_MSK);
+
+				if (pow_mode != BME680_SLEEP_MODE) {
+					tmp_pow_mode = tmp_pow_mode & (~BME680_MODE_MSK); /* Set to sleep */
+					rslt = bme680_set_regs(&reg_addr, &tmp_pow_mode, 1, dev);
+					dev->delay_ms(BME680_POLL_PERIOD_MS);
+				}
+			}
+		} while (pow_mode != BME680_SLEEP_MODE);
+
+		/* Already in sleep */
+		if (dev->power_mode != BME680_SLEEP_MODE) {
+			tmp_pow_mode = (tmp_pow_mode & ~BME680_MODE_MSK) | (dev->power_mode & BME680_MODE_MSK);
+			if (rslt == BME680_OK)
+				rslt = bme680_set_regs(&reg_addr, &tmp_pow_mode, 1, dev);
+		}
+	} else {
+		TRACE_ERROR("Nullpointer exception.");
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API is used to get the power mode of the sensor.
+ */
+int8_t bme680_get_sensor_mode(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t mode;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		rslt = bme680_get_regs(BME680_CONF_T_P_MODE_ADDR, &mode, 1, dev);
+		/* Masking the other register bit info*/
+		dev->power_mode = mode & BME680_MODE_MSK;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This API is used to set the profile duration of the sensor.
+ */
+void bme680_set_profile_dur(uint16_t duration, struct bme680_dev *dev)
+{
+	uint32_t tph_dur; /* Calculate in us */
+	uint32_t meas_cycles;
+	uint8_t os_to_meas_cycles[6] = {0, 1, 2, 4, 8, 16};
+
+	meas_cycles = os_to_meas_cycles[dev->tph_sett.os_temp];
+	meas_cycles += os_to_meas_cycles[dev->tph_sett.os_pres];
+	meas_cycles += os_to_meas_cycles[dev->tph_sett.os_hum];
+
+	/* TPH measurement duration */
+	tph_dur = meas_cycles * UINT32_C(1963);
+	tph_dur += UINT32_C(477 * 4); /* TPH switching duration */
+	tph_dur += UINT32_C(477 * 5); /* Gas measurement duration */
+	tph_dur += UINT32_C(500); /* Get it to the closest whole number.*/
+	tph_dur /= UINT32_C(1000); /* Convert to ms */
+
+	tph_dur += UINT32_C(1); /* Wake up duration of 1ms */
+	/* The remaining time should be used for heating */
+	dev->gas_sett.heatr_dur = duration - (uint16_t) tph_dur;
+}
+
+/*!
+ * @brief This API is used to get the profile duration of the sensor.
+ */
+void bme680_get_profile_dur(uint16_t *duration, const struct bme680_dev *dev)
+{
+	uint32_t tph_dur; /* Calculate in us */
+	uint32_t meas_cycles;
+	uint8_t os_to_meas_cycles[6] = {0, 1, 2, 4, 8, 16};
+
+	meas_cycles = os_to_meas_cycles[dev->tph_sett.os_temp];
+	meas_cycles += os_to_meas_cycles[dev->tph_sett.os_pres];
+	meas_cycles += os_to_meas_cycles[dev->tph_sett.os_hum];
+
+	/* TPH measurement duration */
+	tph_dur = meas_cycles * UINT32_C(1963);
+	tph_dur += UINT32_C(477 * 4); /* TPH switching duration */
+	tph_dur += UINT32_C(477 * 5); /* Gas measurement duration */
+	tph_dur += UINT32_C(500); /* Get it to the closest whole number.*/
+	tph_dur /= UINT32_C(1000); /* Convert to ms */
+
+	tph_dur += UINT32_C(1); /* Wake up duration of 1ms */
+
+	*duration = (uint16_t) tph_dur;
+
+	/* Get the gas duration only when the run gas is enabled */
+	if (dev->gas_sett.run_gas) {
+		/* The remaining time should be used for heating */
+		*duration += dev->gas_sett.heatr_dur;
+	}
+}
+
+/*!
+ * @brief This API reads the pressure, temperature and humidity and gas data
+ * from the sensor, compensates the data and store it in the bme680_data
+ * structure instance passed by the user.
+ */
+int8_t bme680_get_sensor_data(struct bme680_field_data *data, struct bme680_dev *dev)
+{
+	int8_t rslt;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		/* Reading the sensor data in forced mode only */
+		rslt = read_field_data(data, dev);
+		if (rslt == BME680_OK) {
+			if (data->status & BME680_NEW_DATA_MSK)
+				dev->new_fields = 1;
+			else
+				dev->new_fields = 0;
+		}
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to read the calibrated data from the sensor.
+ */
+static int8_t get_calib_data(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t coeff_array[BME680_COEFF_SIZE] = { 0 };
+	uint8_t temp_var = 0; /* Temporary variable */
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		rslt = bme680_get_regs(BME680_COEFF_ADDR1, coeff_array, BME680_COEFF_ADDR1_LEN, dev);
+		/* Append the second half in the same array */
+		if (rslt == BME680_OK)
+			rslt = bme680_get_regs(BME680_COEFF_ADDR2, &coeff_array[BME680_COEFF_ADDR1_LEN]
+			, BME680_COEFF_ADDR2_LEN, dev);
+
+		/* Temperature related coefficients */
+		dev->calib.par_t1 = (uint16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_T1_MSB_REG],
+			coeff_array[BME680_T1_LSB_REG]));
+		dev->calib.par_t2 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_T2_MSB_REG],
+			coeff_array[BME680_T2_LSB_REG]));
+		dev->calib.par_t3 = (int8_t) (coeff_array[BME680_T3_REG]);
+
+		/* Pressure related coefficients */
+		dev->calib.par_p1 = (uint16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P1_MSB_REG],
+			coeff_array[BME680_P1_LSB_REG]));
+		dev->calib.par_p2 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P2_MSB_REG],
+			coeff_array[BME680_P2_LSB_REG]));
+		dev->calib.par_p3 = (int8_t) coeff_array[BME680_P3_REG];
+		dev->calib.par_p4 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P4_MSB_REG],
+			coeff_array[BME680_P4_LSB_REG]));
+		dev->calib.par_p5 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P5_MSB_REG],
+			coeff_array[BME680_P5_LSB_REG]));
+		dev->calib.par_p6 = (int8_t) (coeff_array[BME680_P6_REG]);
+		dev->calib.par_p7 = (int8_t) (coeff_array[BME680_P7_REG]);
+		dev->calib.par_p8 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P8_MSB_REG],
+			coeff_array[BME680_P8_LSB_REG]));
+		dev->calib.par_p9 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_P9_MSB_REG],
+			coeff_array[BME680_P9_LSB_REG]));
+		dev->calib.par_p10 = (uint8_t) (coeff_array[BME680_P10_REG]);
+
+		/* Humidity related coefficients */
+		dev->calib.par_h1 = (uint16_t) (((uint16_t) coeff_array[BME680_H1_MSB_REG] << BME680_HUM_REG_SHIFT_VAL)
+			| (coeff_array[BME680_H1_LSB_REG] & BME680_BIT_H1_DATA_MSK));
+		dev->calib.par_h2 = (uint16_t) (((uint16_t) coeff_array[BME680_H2_MSB_REG] << BME680_HUM_REG_SHIFT_VAL)
+			| ((coeff_array[BME680_H2_LSB_REG]) >> BME680_HUM_REG_SHIFT_VAL));
+		dev->calib.par_h3 = (int8_t) coeff_array[BME680_H3_REG];
+		dev->calib.par_h4 = (int8_t) coeff_array[BME680_H4_REG];
+		dev->calib.par_h5 = (int8_t) coeff_array[BME680_H5_REG];
+		dev->calib.par_h6 = (uint8_t) coeff_array[BME680_H6_REG];
+		dev->calib.par_h7 = (int8_t) coeff_array[BME680_H7_REG];
+
+		/* Gas heater related coefficients */
+		dev->calib.par_gh1 = (int8_t) coeff_array[BME680_GH1_REG];
+		dev->calib.par_gh2 = (int16_t) (BME680_CONCAT_BYTES(coeff_array[BME680_GH2_MSB_REG],
+			coeff_array[BME680_GH2_LSB_REG]));
+		dev->calib.par_gh3 = (int8_t) coeff_array[BME680_GH3_REG];
+
+		/* Other coefficients */
+		if (rslt == BME680_OK) {
+			rslt = bme680_get_regs(BME680_ADDR_RES_HEAT_RANGE_ADDR, &temp_var, 1, dev);
+
+			dev->calib.res_heat_range = ((temp_var & BME680_RHRANGE_MSK) / 16);
+			if (rslt == BME680_OK) {
+				rslt = bme680_get_regs(BME680_ADDR_RES_HEAT_VAL_ADDR, &temp_var, 1, dev);
+
+				dev->calib.res_heat_val = (int8_t) temp_var;
+				if (rslt == BME680_OK)
+					rslt = bme680_get_regs(BME680_ADDR_RANGE_SW_ERR_ADDR, &temp_var, 1, dev);
+			}
+		}
+		dev->calib.range_sw_err = ((int8_t) temp_var & (int8_t) BME680_RSERROR_MSK) / 16;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to set the gas configuration of the sensor.
+ */
+static int8_t set_gas_config(struct bme680_dev *dev)
+{
+	int8_t rslt;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+
+		uint8_t reg_addr[2] = {0};
+		uint8_t reg_data[2] = {0};
+
+		if (dev->power_mode == BME680_FORCED_MODE) {
+			reg_addr[0] = BME680_RES_HEAT0_ADDR;
+			reg_data[0] = calc_heater_res(dev->gas_sett.heatr_temp, dev);
+			reg_addr[1] = BME680_GAS_WAIT0_ADDR;
+			reg_data[1] = calc_heater_dur(dev->gas_sett.heatr_dur);
+			dev->gas_sett.nb_conv = 0;
+		} else {
+			rslt = BME680_W_DEFINE_PWR_MODE;
+		}
+		if (rslt == BME680_OK)
+			rslt = bme680_set_regs(reg_addr, reg_data, 2, dev);
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to get the gas configuration of the sensor.
+ * @note heatr_temp and heatr_dur values are currently register data
+ * and not the actual values set
+ */
+static int8_t get_gas_config(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	/* starting address of the register array for burst read*/
+	uint8_t reg_addr1 = BME680_ADDR_SENS_CONF_START;
+	uint8_t reg_addr2 = BME680_ADDR_GAS_CONF_START;
+	uint8_t reg_data = 0;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if (BME680_SPI_INTF == dev->intf) {
+			/* Memory page switch the SPI address*/
+			rslt = set_mem_page(reg_addr1, dev);
+		}
+
+		if (rslt == BME680_OK) {
+			rslt = bme680_get_regs(reg_addr1, &reg_data, 1, dev);
+			if (rslt == BME680_OK) {
+				dev->gas_sett.heatr_temp = reg_data;
+				rslt = bme680_get_regs(reg_addr2, &reg_data, 1, dev);
+				if (rslt == BME680_OK) {
+					/* Heating duration register value */
+					dev->gas_sett.heatr_dur = reg_data;
+				}
+			}
+		}
+	}
+
+	return rslt;
+}
+
+#ifndef BME680_FLOAT_POINT_COMPENSATION
+
+/*!
+ * @brief This internal API is used to calculate the temperature value.
+ */
+static int16_t calc_temperature(uint32_t temp_adc, struct bme680_dev *dev)
+{
+	int64_t var1;
+	int64_t var2;
+	int64_t var3;
+	int16_t calc_temp;
+
+	var1 = ((int32_t) temp_adc >> 3) - ((int32_t) dev->calib.par_t1 << 1);
+	var2 = (var1 * (int32_t) dev->calib.par_t2) >> 11;
+	var3 = ((var1 >> 1) * (var1 >> 1)) >> 12;
+	var3 = ((var3) * ((int32_t) dev->calib.par_t3 << 4)) >> 14;
+	dev->calib.t_fine = (int32_t) (var2 + var3);
+	calc_temp = (int16_t) (((dev->calib.t_fine * 5) + 128) >> 8);
+
+	return calc_temp;
+}
+
+/*!
+ * @brief This internal API is used to calculate the pressure value.
+ */
+static uint32_t calc_pressure(uint32_t pres_adc, const struct bme680_dev *dev)
+{
+	int32_t var1;
+	int32_t var2;
+	int32_t var3;
+	int32_t pressure_comp;
+
+	var1 = (((int32_t)dev->calib.t_fine) >> 1) - 64000;
+	var2 = ((((var1 >> 2) * (var1 >> 2)) >> 11) *
+		(int32_t)dev->calib.par_p6) >> 2;
+	var2 = var2 + ((var1 * (int32_t)dev->calib.par_p5) << 1);
+	var2 = (var2 >> 2) + ((int32_t)dev->calib.par_p4 << 16);
+	var1 = (((((var1 >> 2) * (var1 >> 2)) >> 13) *
+		((int32_t)dev->calib.par_p3 << 5)) >> 3) +
+		(((int32_t)dev->calib.par_p2 * var1) >> 1);
+	var1 = var1 >> 18;
+	var1 = ((32768 + var1) * (int32_t)dev->calib.par_p1) >> 15;
+	pressure_comp = 1048576 - pres_adc;
+	pressure_comp = (int32_t)((pressure_comp - (var2 >> 12)) * ((uint32_t)3125));
+	if (pressure_comp >= BME680_MAX_OVERFLOW_VAL)
+		pressure_comp = ((pressure_comp / var1) << 1);
+	else
+		pressure_comp = ((pressure_comp << 1) / var1);
+	var1 = ((int32_t)dev->calib.par_p9 * (int32_t)(((pressure_comp >> 3) *
+		(pressure_comp >> 3)) >> 13)) >> 12;
+	var2 = ((int32_t)(pressure_comp >> 2) *
+		(int32_t)dev->calib.par_p8) >> 13;
+	var3 = ((int32_t)(pressure_comp >> 8) * (int32_t)(pressure_comp >> 8) *
+		(int32_t)(pressure_comp >> 8) *
+		(int32_t)dev->calib.par_p10) >> 17;
+
+	pressure_comp = (int32_t)(pressure_comp) + ((var1 + var2 + var3 +
+		((int32_t)dev->calib.par_p7 << 7)) >> 4);
+
+	return (uint32_t)pressure_comp;
+
+}
+
+/*!
+ * @brief This internal API is used to calculate the humidity value.
+ */
+static uint32_t calc_humidity(uint16_t hum_adc, const struct bme680_dev *dev)
+{
+	int32_t var1;
+	int32_t var2;
+	int32_t var3;
+	int32_t var4;
+	int32_t var5;
+	int32_t var6;
+	int32_t temp_scaled;
+	int32_t calc_hum;
+
+	temp_scaled = (((int32_t) dev->calib.t_fine * 5) + 128) >> 8;
+	var1 = (int32_t) (hum_adc - ((int32_t) ((int32_t) dev->calib.par_h1 * 16)))
+		- (((temp_scaled * (int32_t) dev->calib.par_h3) / ((int32_t) 100)) >> 1);
+	var2 = ((int32_t) dev->calib.par_h2
+		* (((temp_scaled * (int32_t) dev->calib.par_h4) / ((int32_t) 100))
+			+ (((temp_scaled * ((temp_scaled * (int32_t) dev->calib.par_h5) / ((int32_t) 100))) >> 6)
+				/ ((int32_t) 100)) + (int32_t) (1 << 14))) >> 10;
+	var3 = var1 * var2;
+	var4 = (int32_t) dev->calib.par_h6 << 7;
+	var4 = ((var4) + ((temp_scaled * (int32_t) dev->calib.par_h7) / ((int32_t) 100))) >> 4;
+	var5 = ((var3 >> 14) * (var3 >> 14)) >> 10;
+	var6 = (var4 * var5) >> 1;
+	calc_hum = (((var3 + var6) >> 10) * ((int32_t) 1000)) >> 12;
+
+	if (calc_hum > 100000) /* Cap at 100%rH */
+		calc_hum = 100000;
+	else if (calc_hum < 0)
+		calc_hum = 0;
+
+	return (uint32_t) calc_hum;
+}
+
+/*!
+ * @brief This internal API is used to calculate the Gas Resistance value.
+ */
+static uint32_t calc_gas_resistance(uint16_t gas_res_adc, uint8_t gas_range, const struct bme680_dev *dev)
+{
+	int64_t var1;
+	uint64_t var2;
+	int64_t var3;
+	uint32_t calc_gas_res;
+	/**Look up table 1 for the possible gas range values */
+	uint32_t lookupTable1[16] = { UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647),
+		UINT32_C(2147483647), UINT32_C(2126008810), UINT32_C(2147483647), UINT32_C(2130303777),
+		UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2143188679), UINT32_C(2136746228),
+		UINT32_C(2147483647), UINT32_C(2126008810), UINT32_C(2147483647), UINT32_C(2147483647) };
+	/**Look up table 2 for the possible gas range values */
+	uint32_t lookupTable2[16] = { UINT32_C(4096000000), UINT32_C(2048000000), UINT32_C(1024000000), UINT32_C(512000000),
+		UINT32_C(255744255), UINT32_C(127110228), UINT32_C(64000000), UINT32_C(32258064), UINT32_C(16016016),
+		UINT32_C(8000000), UINT32_C(4000000), UINT32_C(2000000), UINT32_C(1000000), UINT32_C(500000),
+		UINT32_C(250000), UINT32_C(125000) };
+
+	var1 = (int64_t) ((1340 + (5 * (int64_t) dev->calib.range_sw_err)) *
+		((int64_t) lookupTable1[gas_range])) >> 16;
+	var2 = (((int64_t) ((int64_t) gas_res_adc << 15) - (int64_t) (16777216)) + var1);
+	var3 = (((int64_t) lookupTable2[gas_range] * (int64_t) var1) >> 9);
+	calc_gas_res = (uint32_t) ((var3 + ((int64_t) var2 >> 1)) / (int64_t) var2);
+
+	return calc_gas_res;
+}
+
+/*!
+ * @brief This internal API is used to calculate the Heat Resistance value.
+ */
+static uint8_t calc_heater_res(uint16_t temp, const struct bme680_dev *dev)
+{
+	uint8_t heatr_res;
+	int32_t var1;
+	int32_t var2;
+	int32_t var3;
+	int32_t var4;
+	int32_t var5;
+	int32_t heatr_res_x100;
+
+	if (temp > 400) /* Cap temperature */
+		temp = 400;
+
+	var1 = (((int32_t) dev->amb_temp * dev->calib.par_gh3) / 1000) * 256;
+	var2 = (dev->calib.par_gh1 + 784) * (((((dev->calib.par_gh2 + 154009) * temp * 5) / 100) + 3276800) / 10);
+	var3 = var1 + (var2 / 2);
+	var4 = (var3 / (dev->calib.res_heat_range + 4));
+	var5 = (131 * dev->calib.res_heat_val) + 65536;
+	heatr_res_x100 = (int32_t) (((var4 / var5) - 250) * 34);
+	heatr_res = (uint8_t) ((heatr_res_x100 + 50) / 100);
+
+	return heatr_res;
+}
+
+#else
+
+
+/*!
+ * @brief This internal API is used to calculate the
+ * temperature value in float format
+ */
+static float calc_temperature(uint32_t temp_adc, struct bme680_dev *dev)
+{
+	float var1 = 0;
+	float var2 = 0;
+	float calc_temp = 0;
+
+	/* calculate var1 data */
+	var1  = ((((float)temp_adc / 16384.0f) - ((float)dev->calib.par_t1 / 1024.0f))
+			* ((float)dev->calib.par_t2));
+
+	/* calculate var2 data */
+	var2  = (((((float)temp_adc / 131072.0f) - ((float)dev->calib.par_t1 / 8192.0f)) *
+		(((float)temp_adc / 131072.0f) - ((float)dev->calib.par_t1 / 8192.0f))) *
+		((float)dev->calib.par_t3 * 16.0f));
+
+	/* t_fine value*/
+	dev->calib.t_fine = (var1 + var2);
+
+	/* compensated temperature data*/
+	calc_temp  = ((dev->calib.t_fine) / 5120.0f);
+
+	return calc_temp;
+}
+
+/*!
+ * @brief This internal API is used to calculate the
+ * pressure value in float format
+ */
+static float calc_pressure(uint32_t pres_adc, const struct bme680_dev *dev)
+{
+	float var1 = 0;
+	float var2 = 0;
+	float var3 = 0;
+	float calc_pres = 0;
+
+	var1 = (((float)dev->calib.t_fine / 2.0f) - 64000.0f);
+	var2 = var1 * var1 * (((float)dev->calib.par_p6) / (131072.0f));
+	var2 = var2 + (var1 * ((float)dev->calib.par_p5) * 2.0f);
+	var2 = (var2 / 4.0f) + (((float)dev->calib.par_p4) * 65536.0f);
+	var1 = (((((float)dev->calib.par_p3 * var1 * var1) / 16384.0f)
+		+ ((float)dev->calib.par_p2 * var1)) / 524288.0f);
+	var1 = ((1.0f + (var1 / 32768.0f)) * ((float)dev->calib.par_p1));
+	calc_pres = (1048576.0f - ((float)pres_adc));
+
+	/* Avoid exception caused by division by zero */
+	if ((int)var1 != 0) {
+		calc_pres = (((calc_pres - (var2 / 4096.0f)) * 6250.0f) / var1);
+		var1 = (((float)dev->calib.par_p9) * calc_pres * calc_pres) / 2147483648.0f;
+		var2 = calc_pres * (((float)dev->calib.par_p8) / 32768.0f);
+		var3 = ((calc_pres / 256.0f) * (calc_pres / 256.0f) * (calc_pres / 256.0f)
+			* (dev->calib.par_p10 / 131072.0f));
+		calc_pres = (calc_pres + (var1 + var2 + var3 + ((float)dev->calib.par_p7 * 128.0f)) / 16.0f);
+	} else {
+		calc_pres = 0;
+	}
+
+	return calc_pres;
+}
+
+/*!
+ * @brief This internal API is used to calculate the
+ * humidity value in float format
+ */
+static float calc_humidity(uint16_t hum_adc, const struct bme680_dev *dev)
+{
+	float calc_hum = 0;
+	float var1 = 0;
+	float var2 = 0;
+	float var3 = 0;
+	float var4 = 0;
+	float temp_comp;
+
+	/* compensated temperature data*/
+	temp_comp  = ((dev->calib.t_fine) / 5120.0f);
+
+	var1 = (float)((float)hum_adc) - (((float)dev->calib.par_h1 * 16.0f) + (((float)dev->calib.par_h3 / 2.0f)
+		* temp_comp));
+
+	var2 = var1 * ((float)(((float) dev->calib.par_h2 / 262144.0f) * (1.0f + (((float)dev->calib.par_h4 / 16384.0f)
+		* temp_comp) + (((float)dev->calib.par_h5 / 1048576.0f) * temp_comp * temp_comp))));
+
+	var3 = (float) dev->calib.par_h6 / 16384.0f;
+
+	var4 = (float) dev->calib.par_h7 / 2097152.0f;
+
+	calc_hum = var2 + ((var3 + (var4 * temp_comp)) * var2 * var2);
+
+	if (calc_hum > 100.0f)
+		calc_hum = 100.0f;
+	else if (calc_hum < 0.0f)
+		calc_hum = 0.0f;
+
+	return calc_hum;
+}
+
+/*!
+ * @brief This internal API is used to calculate the
+ * gas resistance value in float format
+ */
+static float calc_gas_resistance(uint16_t gas_res_adc, uint8_t gas_range, const struct bme680_dev *dev)
+{
+	float calc_gas_res;
+	float var1 = 0;
+	float var2 = 0;
+	float var3 = 0;
+
+	const float lookup_k1_range[16] = {
+	0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, -0.8,
+	0.0, 0.0, -0.2, -0.5, 0.0, -1.0, 0.0, 0.0};
+	const float lookup_k2_range[16] = {
+	0.0, 0.0, 0.0, 0.0, 0.1, 0.7, 0.0, -0.8,
+	-0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+	var1 = (1340.0f + (5.0f * dev->calib.range_sw_err));
+	var2 = (var1) * (1.0f + lookup_k1_range[gas_range]/100.0f);
+	var3 = 1.0f + (lookup_k2_range[gas_range]/100.0f);
+
+	calc_gas_res = 1.0f / (float)(var3 * (0.000000125f) * (float)(1 << gas_range) * (((((float)gas_res_adc)
+		- 512.0f)/var2) + 1.0f));
+
+	return calc_gas_res;
+}
+
+/*!
+ * @brief This internal API is used to calculate the
+ * heater resistance value in float format
+ */
+static float calc_heater_res(uint16_t temp, const struct bme680_dev *dev)
+{
+	float var1 = 0;
+	float var2 = 0;
+	float var3 = 0;
+	float var4 = 0;
+	float var5 = 0;
+	float res_heat = 0;
+
+	if (temp > 400) /* Cap temperature */
+		temp = 400;
+
+	var1 = (((float)dev->calib.par_gh1 / (16.0f)) + 49.0f);
+	var2 = ((((float)dev->calib.par_gh2 / (32768.0f)) * (0.0005f)) + 0.00235f);
+	var3 = ((float)dev->calib.par_gh3 / (1024.0f));
+	var4 = (var1 * (1.0f + (var2 * (float)temp)));
+	var5 = (var4 + (var3 * (float)dev->amb_temp));
+	res_heat = (uint8_t)(3.4f * ((var5 * (4 / (4 + (float)dev->calib.res_heat_range)) *
+		(1/(1 + ((float) dev->calib.res_heat_val * 0.002f)))) - 25));
+
+	return res_heat;
+}
+
+#endif
+
+/*!
+ * @brief This internal API is used to calculate the Heat duration value.
+ */
+static uint8_t calc_heater_dur(uint16_t dur)
+{
+	uint8_t factor = 0;
+	uint8_t durval;
+
+	if (dur >= 0xfc0) {
+		durval = 0xff; /* Max duration*/
+	} else {
+		while (dur > 0x3F) {
+			dur = dur / 4;
+			factor += 1;
+		}
+		durval = (uint8_t) (dur + (factor * 64));
+	}
+
+	return durval;
+}
+
+/*!
+ * @brief This internal API is used to calculate the field data of sensor.
+ */
+static int8_t read_field_data(struct bme680_field_data *data, struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t buff[BME680_FIELD_LENGTH] = { 0 };
+	uint8_t gas_range;
+	uint32_t adc_temp;
+	uint32_t adc_pres;
+	uint16_t adc_hum;
+	uint16_t adc_gas_res;
+	uint8_t tries = 10;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	do {
+		if (rslt == BME680_OK) {
+			rslt = bme680_get_regs(((uint8_t) (BME680_FIELD0_ADDR)), buff, (uint16_t) BME680_FIELD_LENGTH,
+				dev);
+
+			data->status = buff[0] & BME680_NEW_DATA_MSK;
+			data->gas_index = buff[0] & BME680_GAS_INDEX_MSK;
+			data->meas_index = buff[1];
+
+			/* read the raw data from the sensor */
+			adc_pres = (uint32_t) (((uint32_t) buff[2] * 4096) | ((uint32_t) buff[3] * 16)
+				| ((uint32_t) buff[4] / 16));
+			adc_temp = (uint32_t) (((uint32_t) buff[5] * 4096) | ((uint32_t) buff[6] * 16)
+				| ((uint32_t) buff[7] / 16));
+			adc_hum = (uint16_t) (((uint32_t) buff[8] * 256) | (uint32_t) buff[9]);
+			adc_gas_res = (uint16_t) ((uint32_t) buff[13] * 4 | (((uint32_t) buff[14]) / 64));
+			gas_range = buff[14] & BME680_GAS_RANGE_MSK;
+
+			data->status |= buff[14] & BME680_GASM_VALID_MSK;
+			data->status |= buff[14] & BME680_HEAT_STAB_MSK;
+
+			if (data->status & BME680_NEW_DATA_MSK) {
+				data->temperature = calc_temperature(adc_temp, dev);
+				data->pressure = calc_pressure(adc_pres, dev);
+				data->humidity = calc_humidity(adc_hum, dev);
+				data->gas_resistance = calc_gas_resistance(adc_gas_res, gas_range, dev);
+				break;
+			} else {
+				TRACE_INFO("[BME680] No new data. Retrying (%d tries left)", tries);
+			}
+			/* Delay to poll the data */
+			dev->delay_ms(BME680_POLL_PERIOD_MS);
+		}
+		tries--;
+	} while (tries);
+
+	if (!tries)
+		rslt = BME680_W_NO_NEW_DATA;
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to set the memory page based on register address.
+ */
+static int8_t set_mem_page(uint8_t reg_addr, struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t reg;
+	uint8_t mem_page;
+
+	/* Check for null pointers in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		if (reg_addr > 0x7f)
+			mem_page = BME680_MEM_PAGE1;
+		else
+			mem_page = BME680_MEM_PAGE0;
+
+		if (mem_page != dev->mem_page) {
+			dev->mem_page = mem_page;
+
+			dev->com_rslt = dev->read(dev->dev_id, BME680_MEM_PAGE_ADDR | BME680_SPI_RD_MSK, &reg, 1);
+			if (dev->com_rslt != 0)
+				rslt = BME680_E_COM_FAIL;
+
+			if (rslt == BME680_OK) {
+				reg = reg & (~BME680_MEM_PAGE_MSK);
+				reg = reg | (dev->mem_page & BME680_MEM_PAGE_MSK);
+
+				dev->com_rslt = dev->write(dev->dev_id, BME680_MEM_PAGE_ADDR & BME680_SPI_WR_MSK,
+					&reg, 1);
+				if (dev->com_rslt != 0)
+					rslt = BME680_E_COM_FAIL;
+			}
+		}
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to get the memory page based on register address.
+ */
+static int8_t get_mem_page(struct bme680_dev *dev)
+{
+	int8_t rslt;
+	uint8_t reg;
+
+	/* Check for null pointer in the device structure*/
+	rslt = null_ptr_check(dev);
+	if (rslt == BME680_OK) {
+		dev->com_rslt = dev->read(dev->dev_id, BME680_MEM_PAGE_ADDR | BME680_SPI_RD_MSK, &reg, 1);
+		if (dev->com_rslt != 0)
+			rslt = BME680_E_COM_FAIL;
+		else
+			dev->mem_page = reg & BME680_MEM_PAGE_MSK;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to validate the boundary
+ * conditions.
+ */
+static int8_t boundary_check(uint8_t *value, uint8_t min, uint8_t max, struct bme680_dev *dev)
+{
+	int8_t rslt = BME680_OK;
+
+	if (value != NULL) {
+		/* Check if value is below minimum value */
+		if (*value < min) {
+			/* Auto correct the invalid value to minimum value */
+			*value = min;
+			dev->info_msg |= BME680_I_MIN_CORRECTION;
+		}
+		/* Check if value is above maximum value */
+		if (*value > max) {
+			/* Auto correct the invalid value to maximum value */
+			*value = max;
+			dev->info_msg |= BME680_I_MAX_CORRECTION;
+		}
+	} else {
+		rslt = BME680_E_NULL_PTR;
+	}
+
+	return rslt;
+}
+
+/*!
+ * @brief This internal API is used to validate the device structure pointer for
+ * null conditions.
+ */
+static int8_t null_ptr_check(const struct bme680_dev *dev)
+{
+	int8_t rslt;
+
+	if ((dev == NULL) || (dev->read == NULL) || (dev->write == NULL) || (dev->delay_ms == NULL)) {
+		if(dev == NULL)
+			TRACE_ERROR("[BME680] dev == NULL");
+		if(dev->read == NULL)
+			TRACE_ERROR("[BME680] dev->read == NULL");
+		if(dev->write == NULL)
+			TRACE_ERROR("[BME680] dev->write == NULL");
+		if(dev->delay_ms == NULL)
+			TRACE_ERROR("[BME680] dev->delay_ms == NULL");
+			
+		/* Device structure pointer is not valid */
+		rslt = BME680_E_NULL_PTR;
+	} else {
+		/* Device structure is fine */
+		rslt = BME680_OK;
+	}
+
+	return rslt;
+}

--- a/device/sensor/drv/drv_pm_sensirion_sps30/drv_pm_sensirion_sps30.c
+++ b/device/sensor/drv/drv_pm_sensirion_sps30/drv_pm_sensirion_sps30.c
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2019 X-Cite SA (http://www.x-cite.io)
+ * Written by Lemmer El Assal (lemmer@x-cite.io)
+*/
+
+#include "sps30.h"
+#include "sensor.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <aos/aos.h>
+#include <vfs_conf.h>
+#include <vfs_err.h>
+#include <vfs_register.h>
+#include <hal/base.h>
+#include "common.h"
+#include "sensor_drv_api.h"
+#include "sensor_hal.h"
+
+
+#ifndef SPS30_I2C_PORT
+	#define SPS30_I2C_PORT 1
+#endif
+
+#ifndef SPS30_DATA_READ_MIN_INTERVAL
+	#define SPS30_DATA_READ_MIN_INTERVAL 10000
+#endif
+
+#ifndef SPS30_I2C_FREQ
+    #define SPS30_I2C_FREQ 10000
+#endif
+
+#ifndef SPS30_MAX_TRIES
+    #define SPS30_MAX_TRIES 10
+#endif
+
+#ifndef REDTEXT
+#define REDTEXT   "\x1B[31m"
+#endif
+#ifndef GREENTEXT
+#define GREENTEXT   "\x1B[32m"
+#endif
+#ifndef RESETTEXT
+#define RESETTEXT "\x1B[0m"
+#endif
+
+#ifndef TRACE_COLOR
+#define TRACE_COLOR(color, type, fmt, ...)  \
+    do { \
+        HAL_Printf("%s%s|%03d :: [%s] ", color, __func__, __LINE__, type); \
+        HAL_Printf(fmt, ##__VA_ARGS__); \
+        HAL_Printf("%s" RESETTEXT, "\r\n"); \
+    } while(0)
+#endif
+
+#ifndef TRACE_ERROR
+#define TRACE_ERROR(fmt, ...) TRACE_COLOR(REDTEXT, "ERROR", fmt, ##__VA_ARGS__)
+#endif
+
+#ifndef TRACE_INFO
+#define TRACE_INFO(fmt, ...) TRACE_COLOR(GREENTEXT, "INFO", fmt, ##__VA_ARGS__)
+#endif
+
+
+static struct sps30_measurement g_sps30_data_new;
+sensor_obj_t sensor_pm;
+
+
+i2c_dev_t sps30_ctx = {
+    .port = SPS30_I2C_PORT,
+	.config.freq = SPS30_I2C_FREQ,
+	.config.address_width = I2C_MEM_ADDR_SIZE_8BIT,
+    .config.dev_addr = SPS_I2C_ADDRESS,
+}; 
+
+void sensirion_i2c_init();
+s8 sensirion_i2c_read(u8 address, u8* data, u16 count);
+s8 sensirion_i2c_write(u8 address, const u8* data, u16 count);
+void sensirion_sleep_usec(u32 useconds);
+
+
+static int drv_sps30_update_data()
+{
+    static uint32_t prev_update_tick = 0;
+    uint32_t now_tick = 0;
+    int ret = 0;
+    int tries = SPS30_MAX_TRIES;
+
+    now_tick = aos_now_ms();
+    if ((now_tick - prev_update_tick >= SPS30_DATA_READ_MIN_INTERVAL) || (prev_update_tick == 0)) {
+		ret = sps30_start_measurement();
+        if(ret) {
+            TRACE_ERROR("[SPS30] Start measurement failed (returned %d)", ret);
+            return ret;
+        }
+        // SPS30 should spin up here and requires some time to be ready.
+        aos_msleep(2000);
+
+        uint16_t dataready = 0;
+        do {
+            do {
+                ret = sps30_read_data_ready(&dataready);
+                if(ret) {
+                    TRACE_ERROR("[SPS30] Data ready failed (returned %d)", ret);
+                    return ret;
+                }
+                if((dataready & 1) == 0)
+                    aos_msleep(1000); // delay by 1 s before retrying.
+            } while((dataready & 1) == 0);
+
+            if(ret == 0) {
+                ret = sps30_read_measurement(&g_sps30_data_new);
+                if (unlikely(ret != 0)) {
+                    TRACE_ERROR("[SPS30] Read measurement failed (returned %d)", ret);
+                    aos_msleep(1000); // delay by 1 s before retrying.
+                    tries--;
+                } else {
+                    ret = sps30_stop_measurement();
+                    if (unlikely(ret != 0)) {
+                        TRACE_ERROR("[SPS30] Stop measurement failed (returned %d)", ret);
+                        aos_msleep(1000); // delay by 1 s before retrying.
+                        tries--;
+                    }
+                }
+            } else
+                tries--;
+        } while(tries && ret);
+        
+        
+        if(ret == 0)
+            prev_update_tick = now_tick;
+        return ret;
+    }
+    return 0;
+}
+
+
+static void drv_pm_sensirion_sps30_irq_handle(void)
+{
+    /* no handle so far */
+}
+
+static int drv_pm_sensirion_sps30_open(void)
+{
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+
+    return 0;
+}
+
+static int drv_pm_sensirion_sps30_close(void)
+{
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+
+    return 0;
+}
+
+static int drv_pm_sensirion_sps30_read(void *buf, size_t len)
+{
+    int ret = 0;
+    const size_t size = sizeof(pm_data_t);
+    pm_data_t *pdata = (pm_data_t*)buf;
+
+    if ((buf == NULL) || (len < size)){
+        return -1;
+    }
+    
+    ret = drv_sps30_update_data();
+    if(ret)
+        return ret;
+
+    pdata->mc_1p0 = g_sps30_data_new.mc_1p0;
+    pdata->mc_2p5 = g_sps30_data_new.mc_2p5;
+    pdata->mc_4p0 = g_sps30_data_new.mc_4p0;
+    pdata->mc_10p0 = g_sps30_data_new.mc_10p0;
+    pdata->nc_0p5 = g_sps30_data_new.nc_0p5;
+    pdata->nc_1p0 = g_sps30_data_new.nc_1p0;
+    pdata->nc_2p5 = g_sps30_data_new.nc_2p5;
+    pdata->nc_4p0 = g_sps30_data_new.nc_4p0;
+    pdata->nc_10p0 = g_sps30_data_new.nc_10p0;
+    pdata->typical_particle_size = g_sps30_data_new.typical_particle_size;
+    pdata->timestamp = aos_now_ms();
+
+    return (int)size;
+}
+
+static int drv_pm_sensirion_sps30_write(const void *buf, size_t len)
+{
+    (void)buf;
+    (void)len;
+    return 0;
+}
+
+
+static int drv_pm_sensirion_sps30_ioctl(int cmd, unsigned long arg)
+{
+    switch (cmd) {
+        case SENSOR_IOCTL_GET_INFO:
+            {
+                /* fill the dev info here */
+                dev_sensor_info_t *info = (dev_sensor_info_t *)arg;
+                info->model = "SPS30";
+                info->vendor = DEV_SENSOR_VENDOR_SENSIRION;
+            }
+            break;
+        default:
+            return -1;
+    }
+
+    LOG("%s %s successfully \n", SENSOR_STR, __func__);
+    return 0;
+}
+
+int32_t drv_sps30_init() {
+    uint32_t ret = 0;
+    
+    sensirion_i2c_init();
+
+    char serial[SPS_MAX_SERIAL_LEN];
+    ret = sps30_get_serial(serial);
+    if(!ret)
+        TRACE_INFO("[SPS30] Serial: %s", serial);
+    else
+        TRACE_ERROR("[SPS30] Get serial failed (returned %d).", ret);
+
+	memset(&sensor_pm, 0, sizeof(sensor_pm));
+	/* fill the sensor_pm obj parameters here */
+	sensor_pm.tag        = TAG_DEV_PM;
+	sensor_pm.path       = dev_pm_path;
+	sensor_pm.io_port    = SPS30_I2C_PORT;
+	sensor_pm.open       = drv_pm_sensirion_sps30_open;
+	sensor_pm.close      = drv_pm_sensirion_sps30_close;
+	sensor_pm.read       = drv_pm_sensirion_sps30_read;
+	sensor_pm.write      = drv_pm_sensirion_sps30_write;
+	sensor_pm.ioctl      = drv_pm_sensirion_sps30_ioctl;
+	sensor_pm.irq_handle = drv_pm_sensirion_sps30_irq_handle;
+	ret = sensor_create_obj(&sensor_pm);
+	if (unlikely(ret)) {
+		return -1;
+	}
+
+    return ret;
+}
+
+/**
+ * Initialize all hard- and software components that are needed for the I2C
+ * communication.
+ */
+
+void sensirion_i2c_init()
+{
+    hal_i2c_init(&sps30_ctx);
+}
+
+/**
+ * Execute one read transaction on the I2C bus, reading a given number of bytes.
+ * If the device does not acknowledge the read command, an error shall be
+ * returned.
+ *
+ * @param address 7-bit I2C address to read from
+ * @param data    pointer to the buffer where the data is to be stored
+ * @param count   number of bytes to read from I2C and store in the buffer
+ * @returns 0 on success, error code otherwise
+ */
+s8 sensirion_i2c_read(u8 address, u8* data, u16 count)
+{
+    return hal_i2c_master_recv(&sps30_ctx, address, data, count, 1000);
+}
+
+/**
+ * Execute one write transaction on the I2C bus, sending a given number of bytes.
+ * The bytes in the supplied buffer must be sent to the given address. If the
+ * slave device does not acknowledge any of the bytes, an error shall be
+ * returned.
+ *
+ * @param address 7-bit I2C address to write to
+ * @param data    pointer to the buffer containing the data to write
+ * @param count   number of bytes to read from the buffer and send over I2C
+ * @returns 0 on success, error code otherwise
+ */
+s8 sensirion_i2c_write(u8 address, const u8* data, u16 count)
+{
+    return hal_i2c_master_send(&sps30_ctx, address, data, count, 1000);
+}
+
+/**
+ * Sleep for a given number of microseconds. The function should delay the
+ * execution for at least the given time, but may also sleep longer.
+ *
+ * Despite the unit, a <10 millisecond precision is sufficient.
+ *
+ * @param useconds the sleep time in microseconds
+ */
+void sensirion_sleep_usec(u32 useconds) {
+    int mseconds = (int) useconds / 1000;
+    if(mseconds == 0)
+        aos_msleep(1);
+    else
+        aos_msleep(mseconds);
+}

--- a/device/sensor/drv/drv_pm_sensirion_sps30/sensirion_arch_config.h
+++ b/device/sensor/drv/drv_pm_sensirion_sps30/sensirion_arch_config.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2018, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SENSIRION_ARCH_CONFIG_H
+#define SENSIRION_ARCH_CONFIG_H
+
+/**
+ * If your platform does not provide the library stdint.h you have to
+ * define the integral types yourself (see below).
+ */
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Typedef section for types commonly defined in <stdint.h>
+ * If your system does not provide stdint headers, please define them
+ * accordingly. Please make sure to define int64_t and uint64_t.
+ */
+/* typedef unsigned long long int uint64_t;
+ * typedef long long int int64_t;
+ * typedef long int32_t;
+ * typedef unsigned long uint32_t;
+ * typedef short int16_t;
+ * typedef unsigned short uint16_t;
+ * typedef char int8_t;
+ * typedef unsigned char uint8_t; */
+
+/**
+ * Comment out the following block if your platform already provides the
+ * type definitions u8, u16, u32, u64, s8, s16, s32, s64.
+ */
+typedef int64_t s64;
+typedef uint64_t u64;
+typedef int32_t s32;
+typedef uint32_t u32;
+typedef int16_t s16;
+typedef uint16_t u16;
+typedef int8_t s8;
+typedef uint8_t u8;
+
+/* Types not typically provided by <stdint.h> */
+typedef float f32;
+
+/**
+ * Define the endianness of your architecture:
+ * 0: little endian, 1: big endian
+ * Use the following code to determine if unsure:
+ * ```c
+ * #include <stdio.h>
+ *
+ * int is_big_endian(void) {
+ *     union {
+ *         unsigned int u;
+ *         char c[sizeof(unsigned int)];
+ *     } e = { 0 };
+ *     e.c[0] = 1;
+ *
+ *     return (e.i != 1);
+ * }
+ *
+ * int main(void) {
+ *     printf("Use #define SENSIRION_BIG_ENDIAN %d\n", is_big_endian());
+ *
+ *     return 0;
+ * }
+ * ```
+ */
+#define SENSIRION_BIG_ENDIAN 0
+
+/**
+ * The clock period of the i2c bus in microseconds. Increase this, if your GPIO
+ * ports cannot support a 200 kHz output rate. (2 * 1 / 10usec == 200Khz)
+ *
+ * This is only relevant for the sw-i2c HAL (bit-banging on GPIO pins). The
+ * pulse length is half the clock period, the number should thus be even.
+ */
+#define SENSIRION_I2C_CLOCK_PERIOD_USEC 10
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SENSIRION_ARCH_CONFIG_H */

--- a/device/sensor/drv/drv_pm_sensirion_sps30/sensirion_common.c
+++ b/device/sensor/drv/drv_pm_sensirion_sps30/sensirion_common.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2018, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *
+ * This module provides functionality that is common to all Sensirion drivers
+ */
+
+#include "sensirion_i2c.h"
+#include "sensirion_common.h"
+
+/* #define EXAMPLE_TRACE(fmt, ...)  \
+    do { \
+        HAL_Printf("%s|%03d :: ", __func__, __LINE__); \
+        HAL_Printf(fmt, ##__VA_ARGS__); \
+        HAL_Printf("%s", "\r\n"); \
+    } while(0) */
+
+
+
+u8 sensirion_common_generate_crc(u8 *data, u16 count)
+{
+    u16 current_byte;
+    u8 crc = CRC8_INIT;
+    u8 crc_bit;
+
+    /* calculates 8-Bit checksum with given polynomial */
+    for (current_byte = 0; current_byte < count; ++current_byte) {
+        crc ^= (data[current_byte]);
+        for (crc_bit = 8; crc_bit > 0; --crc_bit) {
+            if (crc & 0x80)
+                crc = (crc << 1) ^ CRC8_POLYNOMIAL;
+            else
+                crc = (crc << 1);
+        }
+    }
+    return crc;
+}
+
+s8 sensirion_common_check_crc(u8 *data, u16 count, u8 checksum)
+{
+    u8 res = sensirion_common_generate_crc(data, count);
+    if (res != checksum) {
+        //EXAMPLE_TRACE("sensirion_common_generate_crc(%02x %02x,%d) ==  0x%02x != 0x%02x", *(data+1), *(data+0), count, res, checksum);
+        return STATUS_FAIL;
+    }
+        
+    return STATUS_OK;
+}
+
+u16 sensirion_fill_cmd_send_buf(u8 *buf, u16 cmd, const u16 *args, u8 num_args)
+{
+    u8 crc;
+    u8 i;
+    u16 idx = 0;
+
+    buf[idx++] = (u8)((cmd & 0xFF00) >> 8);
+    buf[idx++] = (u8)((cmd & 0x00FF) >> 0);
+
+    for (i = 0; i < num_args; ++i) {
+        buf[idx++] = (u8)((args[i] & 0xFF00) >> 8);
+        buf[idx++] = (u8)((args[i] & 0x00FF) >> 0);
+
+        crc = sensirion_common_generate_crc((u8 *)&buf[idx - 2],
+                                            SENSIRION_WORD_SIZE);
+        buf[idx++] = crc;
+    }
+    return idx;
+}
+
+s16 sensirion_i2c_read_bytes(u8 address, u8 *data, u16 num_words) {
+    s16 ret;
+    u16 i, j;
+    u16 size = num_words * (SENSIRION_WORD_SIZE + CRC8_LEN);
+    u16 word_buf[SENSIRION_MAX_BUFFER_WORDS];
+    u8 * const buf8 = (u8 *)word_buf;
+
+    ret = sensirion_i2c_read(address, buf8, size);
+    if (ret != STATUS_OK) {
+        //EXAMPLE_TRACE("sensirion_i2c_read(%d, 0x%x, %d) returned %d", address, buf8, size, ret);
+        return ret;
+    }
+    /* check the CRC for each word */
+    for (i = 0, j = 0; i < size; i += SENSIRION_WORD_SIZE + CRC8_LEN) {
+
+        ret = sensirion_common_check_crc(&buf8[i], SENSIRION_WORD_SIZE,
+                                         buf8[i + SENSIRION_WORD_SIZE]);
+        if (ret != STATUS_OK) {
+            //EXAMPLE_TRACE("sensirion_common_check_crc returned %d (byte %d)",ret,i);
+            return ret;
+        }
+
+        data[j++] = buf8[i];
+        data[j++] = buf8[i + 1];
+    }
+
+    return STATUS_OK;
+}
+
+s16 sensirion_i2c_read_words(u8 address, u16 *data_words, u16 num_words) {
+    s16 ret;
+    u8 i;
+
+    ret = sensirion_i2c_read_bytes(address, (u8 *)data_words, num_words);
+    if (ret != STATUS_OK) {
+        //EXAMPLE_TRACE("sensirion_i2c_read_bytes returned %d", ret);
+        return ret;
+    }
+
+    for (i = 0; i < num_words; ++i)
+        data_words[i] = be16_to_cpu(data_words[i]);
+
+    return STATUS_OK;
+}
+
+s16 sensirion_i2c_write_cmd(u8 address, u16 command) {
+    u8 buf[SENSIRION_COMMAND_SIZE];
+
+    sensirion_fill_cmd_send_buf(buf, command, NULL, 0);
+    return sensirion_i2c_write(address, buf, SENSIRION_COMMAND_SIZE);
+}
+
+s16 sensirion_i2c_write_cmd_with_args(u8 address, u16 command,
+                                      const u16 *data_words, u16 num_words) {
+    u8 buf[SENSIRION_MAX_BUFFER_WORDS];
+    u16 buf_size;
+
+    buf_size = sensirion_fill_cmd_send_buf(buf, command, data_words, num_words);
+    return sensirion_i2c_write(address, buf, buf_size);
+}
+
+s16 sensirion_i2c_delayed_read_cmd(u8 address, u16 cmd, u32 delay_us,
+                                   u16 *data_words, u16 num_words) {
+    s16 ret;
+    u8 buf[SENSIRION_COMMAND_SIZE];
+
+    sensirion_fill_cmd_send_buf(buf, cmd, NULL, 0);
+    ret = sensirion_i2c_write(address, buf, SENSIRION_COMMAND_SIZE);
+    if (ret != STATUS_OK) {
+        //EXAMPLE_TRACE("sensirion_i2c_write returned %d", ret);
+        return ret;
+    }
+
+    if (delay_us)
+        sensirion_sleep_usec(delay_us);
+
+    return sensirion_i2c_read_words(address, data_words, num_words);
+}
+
+s16 sensirion_i2c_read_cmd(u8 address, u16 cmd, u16 *data_words, u16 num_words)
+{
+    return sensirion_i2c_delayed_read_cmd(address, cmd, 0, data_words,
+                                          num_words);
+}

--- a/device/sensor/drv/drv_pm_sensirion_sps30/sensirion_common.h
+++ b/device/sensor/drv/drv_pm_sensirion_sps30/sensirion_common.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2018, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SENSIRION_COMMON_H
+#define SENSIRION_COMMON_H
+
+#include "sensirion_arch_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STATUS_OK 0
+#define STATUS_FAIL (-1)
+
+#ifndef NULL
+#define NULL ((void *)0)
+#endif
+
+#if SENSIRION_BIG_ENDIAN
+#define be16_to_cpu(s) (s)
+#define be32_to_cpu(s) (s)
+#define be64_to_cpu(s) (s)
+#define SENSIRION_WORDS_TO_BYTES(a, w) ()
+
+#else /* SENSIRION_BIG_ENDIAN */
+
+#define be16_to_cpu(s) (((u16)(s) << 8) | (0xff & ((u16)(s)) >> 8))
+#define be32_to_cpu(s) (((u32)be16_to_cpu(s) << 16) | \
+                        (0xffff & (be16_to_cpu((s) >> 16))))
+#define be64_to_cpu(s) (((u64)be32_to_cpu(s) << 32) | \
+                        (0xffffffff & ((u64)be32_to_cpu((s) >> 32))))
+/**
+ * Convert a word-array to a bytes-array, effectively reverting the
+ * host-endianness to big-endian
+ * @a:  word array to change (must be (u16 *) castable)
+ * @w:  number of word-sized elements in the array (SENSIRION_NUM_WORDS(a)).
+ */
+#define SENSIRION_WORDS_TO_BYTES(a, w) \
+    for (u16 *__a = (u16 *)(a), __e = (w), __w = 0; __w < __e; ++__w) { \
+        __a[__w] = be16_to_cpu(__a[__w]); \
+    }
+#endif /* SENSIRION_BIG_ENDIAN */
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
+#endif
+
+#define CRC8_POLYNOMIAL             0x31
+#define CRC8_INIT                   0xFF
+#define CRC8_LEN                    1
+
+#define SENSIRION_COMMAND_SIZE      2
+#define SENSIRION_WORD_SIZE         2
+#define SENSIRION_NUM_WORDS(x) (sizeof(x) / SENSIRION_WORD_SIZE)
+#define SENSIRION_MAX_BUFFER_WORDS  32
+
+u8 sensirion_common_generate_crc(u8 *data, u16 count);
+
+s8 sensirion_common_check_crc(u8 *data, u16 count, u8 checksum);
+
+/**
+ * sensirion_fill_cmd_send_buf() - create the i2c send buffer for a command and
+ *                                 a set of argument words. The output buffer
+ *                                 interleaves argument words with their
+ *                                 checksums.
+ * @buf:        The generated buffer to send over i2c. Then buffer length must
+ *              be at least SENSIRION_COMMAND_LEN + num_args *
+ *              (SENSIRION_WORD_SIZE + CRC8_LEN).
+ * @cmd:        The i2c command to send. It already includes a checksum.
+ * @args:       The arguments to the command. Can be NULL if none.
+ * @num_args:   The number of word arguments in args.
+ *
+ * @return      The number of bytes written to buf
+ */
+u16 sensirion_fill_cmd_send_buf(u8 *buf, u16 cmd, const u16 *args, u8 num_args);
+
+/**
+ * sensirion_i2c_read_words() - read data words from sensor
+ *
+ * @address:    Sensor i2c address
+ * @data_words: Allocated buffer to store the read words.
+ *              The buffer may also have been modified on STATUS_FAIL return.
+ * @num_words:  Number of data words to read (without CRC bytes)
+ *
+ * @return      STATUS_OK on success, an error code otherwise
+ */
+s16 sensirion_i2c_read_words(u8 address, u16 *data_words, u16 num_words);
+
+/**
+ * sensirion_i2c_read_bytes() - read data words as byte-stream from sensor
+ *
+ * Read bytes without adjusting values to the uP's word-order.
+ *
+ * @address:    Sensor i2c address
+ * @data:       Allocated buffer to store the read bytes.
+ *              The buffer may also have been modified on STATUS_FAIL return.
+ * @num_words:  Number of data words(!) to read (without CRC bytes)
+ *              Since only word-chunks can be read from the sensor the size
+ *              is still specified in sensor-words (num_words = num_bytes *
+ *              SENSIRION_WORD_SIZE)
+ *
+ * @return      STATUS_OK on success, an error code otherwise
+ */
+s16 sensirion_i2c_read_bytes(u8 address, u8 *data, u16 num_words);
+
+/**
+ * sensirion_i2c_write_cmd() - writes a command to the sensor
+ * @address:    Sensor i2c address
+ * @command:    Sensor command
+ *
+ * @return      STATUS_OK on success, an error code otherwise
+ */
+s16 sensirion_i2c_write_cmd(u8 address, u16 command);
+
+/**
+ * sensirion_i2c_write_cmd_with_args() - writes a command with arguments to the
+ *                                       sensor
+ * @address:    Sensor i2c address
+ * @command:    Sensor command
+ * @data:       Argument buffer with words to send
+ * @num_words:  Number of data words to send (without CRC bytes)
+ *
+ * @return      STATUS_OK on success, an error code otherwise
+ */
+s16 sensirion_i2c_write_cmd_with_args(u8 address, u16 command,
+                                      const u16 *data_words, u16 num_words);
+
+/**
+ * sensirion_i2c_delayed_read_cmd() - send a command, wait for the sensor to
+ *                                    process and read data back
+ * @address:    Sensor i2c address
+ * @cmd:        Command
+ * @delay:      Time in microseconds to delay sending the read request
+ * @data_words: Allocated buffer to store the read data
+ * @num_words:  Data words to read (without CRC bytes)
+ *
+ * @return      STATUS_OK on success, an error code otherwise
+ */
+s16 sensirion_i2c_delayed_read_cmd(u8 address, u16 cmd, u32 delay_us,
+                                   u16 *data_words, u16 num_words);
+/**
+ * sensirion_i2c_read_cmd() - reads data words from the sensor after a command
+ *                            is issued
+ * @address:    Sensor i2c address
+ * @cmd:        Command
+ * @data_words: Allocated buffer to store the read data
+ * @num_words:  Data words to read (without CRC bytes)
+ *
+ * @return      STATUS_OK on success, an error code otherwise
+ */
+s16 sensirion_i2c_read_cmd(u8 address, u16 cmd, u16 *data_words, u16 num_words);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SENSIRION_COMMON_H */

--- a/device/sensor/drv/drv_pm_sensirion_sps30/sensirion_i2c.h
+++ b/device/sensor/drv/drv_pm_sensirion_sps30/sensirion_i2c.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SENSIRION_I2C_H
+#define SENSIRION_I2C_H
+
+#include "sensirion_arch_config.h"
+#include "i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+void my_i2c_init(i2c_dev_t *dev);
+
+s8 sensirion_i2c_read(u8 address, u8* data, u16 count);
+
+s8 sensirion_i2c_write(u8 address, const u8* data, u16 count);
+
+void sensirion_sleep_usec(u32 useconds);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* SENSIRION_I2C_H */

--- a/device/sensor/drv/drv_pm_sensirion_sps30/sps30.c
+++ b/device/sensor/drv/drv_pm_sensirion_sps30/sps30.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2018, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sensirion_arch_config.h"
+#include "sensirion_i2c.h"
+#include "sensirion_common.h"
+#include "sps_git_version.h"
+#include "sps30.h"
+
+const char *sps_get_driver_version()
+{
+    return SPS_DRV_VERSION_STR;
+}
+
+s16 sps30_probe() {
+    char serial[SPS_MAX_SERIAL_LEN];
+
+    sensirion_i2c_init();
+
+    return sps30_get_serial(serial);
+}
+
+s16 sps30_get_serial(char *serial) {
+    u16 i;
+    s16 ret;
+    union {
+        char serial[SPS_MAX_SERIAL_LEN];
+        u16 __enforce_alignment;
+    } buffer;
+
+    ret = sensirion_i2c_read_cmd(SPS_I2C_ADDRESS, SPS_CMD_GET_SERIAL,
+                                 (u16 *)buffer.serial,
+                                 SENSIRION_NUM_WORDS(buffer.serial));
+    if (ret != STATUS_OK)
+        return ret;
+
+    SENSIRION_WORDS_TO_BYTES(buffer.serial, SENSIRION_NUM_WORDS(buffer.serial));
+    for (i = 0; i < SPS_MAX_SERIAL_LEN; ++i) {
+        serial[i] = buffer.serial[i];
+        if (serial[i] == '\0')
+            return 0;
+    }
+
+    return 0;
+}
+
+s16 sps30_start_measurement() {
+    const u16 arg = SPS_CMD_START_MEASUREMENT_ARG;
+
+    return sensirion_i2c_write_cmd_with_args(SPS_I2C_ADDRESS,
+                                             SPS_CMD_START_MEASUREMENT,
+                                             &arg,
+                                             SENSIRION_NUM_WORDS(arg));
+}
+
+s16 sps30_stop_measurement() {
+    return sensirion_i2c_write_cmd(SPS_I2C_ADDRESS, SPS_CMD_STOP_MEASUREMENT);
+}
+
+s16 sps30_read_data_ready(u16 *data_ready) {
+    return sensirion_i2c_read_cmd(SPS_I2C_ADDRESS, SPS_CMD_GET_DATA_READY,
+                                  data_ready, SENSIRION_NUM_WORDS(*data_ready));
+}
+
+s16 sps30_read_measurement(struct sps30_measurement *measurement) {
+    s16 ret;
+    u16 idx;
+    union {
+        u16 u16[2];
+        u32 u;
+        f32 f;
+    } val, data[10];
+
+    ret = sensirion_i2c_read_cmd(SPS_I2C_ADDRESS, SPS_CMD_READ_MEASUREMENT,
+                                 data->u16, SENSIRION_NUM_WORDS(data));
+    if (ret != STATUS_OK)
+        return ret;
+
+    SENSIRION_WORDS_TO_BYTES(data->u16, SENSIRION_NUM_WORDS(data));
+
+    idx = 0;
+    val.u = be32_to_cpu(data[idx].u);
+    measurement->mc_1p0 = val.f;
+    ++idx;
+    val.u = be32_to_cpu(data[idx].u);
+    measurement->mc_2p5 = val.f;
+    ++idx;
+    val.u = be32_to_cpu(data[idx].u);
+    measurement->mc_4p0 = val.f;
+    ++idx;
+    val.u = be32_to_cpu(data[idx].u);
+    measurement->mc_10p0 = val.f;
+    ++idx;
+    val.u = be32_to_cpu(data[idx].u);
+    measurement->nc_0p5 = val.f;
+    ++idx;
+    val.u = be32_to_cpu(data[idx].u);
+    measurement->nc_1p0 = val.f;
+    ++idx;
+    val.u = be32_to_cpu(data[idx].u);
+    measurement->nc_2p5 = val.f;
+    ++idx;
+    val.u = be32_to_cpu(data[idx].u);
+    measurement->nc_4p0 = val.f;
+    ++idx;
+    val.u = be32_to_cpu(data[idx].u);
+    measurement->nc_10p0 = val.f;
+    ++idx;
+    val.u = be32_to_cpu(data[idx].u);
+    measurement->typical_particle_size = val.f;
+    ++idx;
+
+    return 0;
+}
+
+s16 sps30_get_fan_auto_cleaning_interval(u32 *interval_seconds) {
+    union {
+        u16 u16[2];
+        u32 u32;
+    } data;
+    s16 ret = sensirion_i2c_read_cmd(SPS_I2C_ADDRESS,
+                                     SPS_CMD_AUTOCLEAN_INTERVAL,
+                                     data.u16, SENSIRION_NUM_WORDS(data.u16));
+    if (ret != STATUS_OK)
+        return ret;
+
+    SENSIRION_WORDS_TO_BYTES(data.u16, SENSIRION_NUM_WORDS(data.u16));
+    *interval_seconds = be32_to_cpu(data.u32);
+
+    return 0;
+}
+
+s16 sps30_set_fan_auto_cleaning_interval(u32 interval_seconds) {
+    s16 ret;
+    const u16 data[] = {(interval_seconds & 0xFFFF0000) >> 16,
+                        (interval_seconds & 0x0000FFFF) >> 0};
+
+    ret = sensirion_i2c_write_cmd_with_args(SPS_I2C_ADDRESS,
+                                            SPS_CMD_AUTOCLEAN_INTERVAL, data,
+                                            SENSIRION_NUM_WORDS(data));
+    sensirion_sleep_usec(SPS_WRITE_DELAY_US);
+    return ret;
+}
+
+s16 sps30_get_fan_auto_cleaning_interval_days(u8 *interval_days) {
+    s16 ret;
+    u32 interval_seconds;
+
+    ret = sps30_get_fan_auto_cleaning_interval(&interval_seconds);
+    if (ret < 0)
+        return ret;
+
+    *interval_days = interval_seconds / (24 * 60 * 60);
+    return ret;
+}
+
+s16 sps30_set_fan_auto_cleaning_interval_days(u8 interval_days) {
+    return sps30_set_fan_auto_cleaning_interval((u32)interval_days *
+                                                24 * 60 * 60);
+}
+
+s16 sps30_reset() {
+    return sensirion_i2c_write_cmd(SPS_I2C_ADDRESS, SPS_CMD_RESET);
+}

--- a/device/sensor/drv/drv_pm_sensirion_sps30/sps30.h
+++ b/device/sensor/drv/drv_pm_sensirion_sps30/sps30.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2018, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SPS30_H
+#define SPS30_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "sensirion_arch_config.h"
+
+#define SPS_MAX_SERIAL_LEN 32
+
+struct sps30_measurement {
+    f32 mc_1p0;
+    f32 mc_2p5;
+    f32 mc_4p0;
+    f32 mc_10p0;
+    f32 nc_0p5;
+    f32 nc_1p0;
+    f32 nc_2p5;
+    f32 nc_4p0;
+    f32 nc_10p0;
+    f32 typical_particle_size;
+};
+
+//static const u8 SPS_I2C_ADDRESS = 0x69;
+#define SPS_I2C_ADDRESS 0x69
+
+
+#define SPS_CMD_START_MEASUREMENT       0x0010
+#define SPS_CMD_START_MEASUREMENT_ARG   0x0300
+#define SPS_CMD_STOP_MEASUREMENT        0x0104
+#define SPS_CMD_READ_MEASUREMENT        0x0300
+#define SPS_CMD_GET_DATA_READY          0x0202
+#define SPS_CMD_AUTOCLEAN_INTERVAL      0x8004
+#define SPS_CMD_GET_SERIAL              0xd033
+#define SPS_CMD_RESET                   0xd304
+#define SPS_WRITE_DELAY_US              20000
+
+
+/**
+ * sps_get_driver_version() - Return the driver version
+ * Return:  Driver version string
+ */
+const char *sps_get_driver_version(void);
+
+/**
+ * sps30_probe() - check if SPS sensor is available and initialize it
+ *
+ * Note that Pin 4 must be pulled to ground for the sensor to operate in i2c
+ * mode (this driver). When left floating, the sensor operates in UART mode
+ * which is not compatible with this i2c driver.
+ *
+ * Return:  0 on success, an error code otherwise
+ */
+s16 sps30_probe();
+
+/**
+ * sps30_get_serial() - retrieve the serial number
+ *
+ * Note that serial must be discarded when the return code is non-zero.
+ *
+ * @serial: Memory where the serial number is written into as hex string (zero
+ *          terminated). Must be at least SPS_MAX_SERIAL_LEN long.
+ * Return:  0 on success, an error code otherwise
+ */
+s16 sps30_get_serial(char *serial);
+
+/**
+ * sps30_start_measurement() - start measuring
+ *
+ * Once the measurement is started, measurements are retrievable once per second
+ * with sps30_read_measurement.
+ *
+ * Return:  0 on success, an error code otherwise
+ */
+s16 sps30_start_measurement();
+
+/**
+ * sps30_stop_measurement() - stop measuring
+ *
+ * Return:  0 on success, an error code otherwise
+ */
+s16 sps30_stop_measurement();
+
+/**
+ * sps30_read_datda_ready() - reads the current data-ready flag
+ *
+ * The data-ready flag indicates that new (not yet retrieved) measurements are
+ * available
+ *
+ * @data_ready: Memory where the data-ready flag (0|1) is stored.
+ * Return:      0 on success, an error code otherwise
+ */
+s16 sps30_read_data_ready(u16 *data_ready);
+
+/**
+ * sps30_read_measurement() - read a measurement
+ *
+ * Read the last measurement.
+ *
+ * Return:  0 on success, an error code otherwise
+ */
+s16 sps30_read_measurement(struct sps30_measurement *measurement);
+
+/**
+ * sps30_get_fan_auto_cleaning_interval() - read the current(*) auto-cleaning
+ * interval
+ *
+ * Note that interval_seconds must be discarded when the return code is
+ * non-zero.
+ *
+ * (*) Note that due to a firmware bug, the reported interval is only updated on
+ * sensor restart/reset. If the interval was thus updated after the last reset,
+ * the old value is still reported. Power-cycle the sensor or call sps30_reset()
+ * first if you need the latest value.
+ *
+ * @interval_seconds:   Memory where the interval in seconds is stored
+ * Return:              0 on success, an error code otherwise
+ */
+s16 sps30_get_fan_auto_cleaning_interval(u32 *interval_seconds);
+
+/**
+ * sps30_set_fan_auto_cleaning_interval() - set the current auto-cleaning
+ * interval
+ *
+ * @interval_seconds:   Value in seconds used to sets the auto-cleaning
+ *                      interval, 0 to disable auto cleaning
+ * Return:              0 on success, an error code otherwise
+ */
+s16 sps30_set_fan_auto_cleaning_interval(u32 interval_seconds);
+
+/**
+ * sps30_get_fan_auto_cleaning_interval_days() - convenience function to read
+ * the current(*) auto-cleaning interval in days
+ *
+ * note that the value is simply cut, not rounded or calculated nicely, thus
+ * using this method is not precise when used in conjunction with
+ * sps30_set_fan_auto_cleaning_interval instead of
+ * sps30_set_fan_auto_cleaning_interval_days
+ *
+ * Note that interval_days must be discarded when the return code is non-zero.
+ *
+ * (*) Note that due to a firmware bug, the reported interval is only updated on
+ * sensor restart/reset. If the interval was thus updated after the last reset,
+ * the old value is still reported. Power-cycle the sensor or call sps30_reset()
+ * first if you need the latest value.
+ *
+ * @interval_days:  Memory where the interval in days is stored
+ * Return:          0 on success, an error code otherwise
+ */
+s16 sps30_get_fan_auto_cleaning_interval_days(u8 *interval_days);
+
+/**
+ * sps30_set_fan_auto_cleaning_interval_days() - convenience function to set the
+ * current auto-cleaning interval in days
+ *
+ * @interval_days:  Value in days used to sets the auto-cleaning interval, 0 to
+ *                  disable auto cleaning
+ * Return:          0 on success, an error code otherwise
+ */
+s16 sps30_set_fan_auto_cleaning_interval_days(u8 interval_days);
+
+/**
+ * sps30_reset() - reset the SGP30
+ *
+ * The sensor reboots to the same state as before the reset but takes a few
+ * seconds to resume measurements.
+ *
+ * Note that the interface-select configuration is reinterpreted, thus Pin 4
+ * must be pulled to ground during the reset period for the sensor to remain in
+ * i2c mode.
+ *
+ * Return:          0 on success, an error code otherwise
+ */
+s16 sps30_reset();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SPS30_H */

--- a/device/sensor/drv/drv_pm_sensirion_sps30/sps_git_version.h
+++ b/device/sensor/drv/drv_pm_sensirion_sps30/sps_git_version.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SPS_GIT_VERSION_H
+#define SPS_GIT_VERSION_H
+
+extern const char * SPS_DRV_VERSION_STR;
+
+#endif /* SPS_GIT_VERSION_H */

--- a/device/sensor/hal/sensor_hal.c
+++ b/device/sensor/hal/sensor_hal.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2015-2017 Alibaba Group Holding Limited
+ * Copyright (C) 2019 X-Cite SA (http://www.x-cite.io)
+ * Sensirion SPS30 and Bosch BME680 support added by Lemmer El Assal (lemmer@x-cite.io)
  */
 
 #include <stdio.h>
@@ -513,6 +515,15 @@ int sensor_init(void)
 #ifdef UDATA_MODBUS
     modbus_init();
 #endif /* UDATA_MODBUS */
+
+#ifdef AOS_SENSOR_GR_BARO_TEMP_HUM_BOSCH_BME680
+    drv_bme680_init(0);
+#endif
+
+#ifdef AOS_SENSOR_PM_SENSIRION_SPS30
+    drv_sps30_init();
+#endif
+
 
     ret = sensor_hal_register();
     if(ret != 0){

--- a/device/sensor/include/sensor.h
+++ b/device/sensor/include/sensor.h
@@ -2,6 +2,8 @@
  * Copyright (C) 2015-2017 Alibaba Group Holding Limited
  *
  *  sensor hal
+ * Copyright (C) 2019 X-Cite SA (http://www.x-cite.io)
+ * Updated by Lemmer El Assal (lemmer@x-cite.io)
  */
 
 #ifndef HAL_SENSOR_H
@@ -83,6 +85,9 @@ typedef enum
 #define dev_gs_path      "/dev/gs"
 #define dev_ir_path      "/dev/ir"
 
+#define dev_gas_resistance_path "/dev/gr" // gas resistance
+#define dev_pm_path "/dev/pm" // pm 0.5, 1.0, 2.5, 4.0, 10.0
+
 #define sensor_node_path "/dev/sensor"
 #define gps_node_path "/dev/nodegps"
 
@@ -103,6 +108,7 @@ typedef enum
 #define DEV_PM25_PATH(x) dev_pm25_path "/" ToString(x)
 #define DEV_PM10_PATH(x) dev_pm10_path "/" ToString(x)
 #define DEV_PM1_PATH(x) dev_pm1_path "/" ToString(x)
+#define DEV_PM_PATH(x) dev_pm_path "/" ToString(x)
 #define DEV_CO2_PATH(x) dev_co2_path "/" ToString(x)
 #define DEV_TVOC_PATH(x) dev_tvoc_path "/" ToString(x)
 
@@ -120,6 +126,7 @@ typedef enum
     TAG_DEV_UV,      /* Ultraviolet */
     TAG_DEV_HUMI,    /* Humidity */
     TAG_DEV_NOISE,   /* NoiseLoudness */
+    TAG_DEV_PM,      /* Collection of PM 0.5 1.0 2.5 4.0 10  - Sensirion SPS30 datatype*/
     TAG_DEV_PM25,    /* PM2.5 */
     TAG_DEV_PM1P0,   /* PM1.0 */
     TAG_DEV_PM10,    /* PM10 */
@@ -140,6 +147,7 @@ typedef enum
     TAG_DEV_GS,         /* Gesture sensor */
     TAG_DEV_IR,         /* IR sensor */
     TAG_DEV_GPS,
+    TAG_DEV_GR,        /* Gas resistance */
     TAG_DEV_SENSOR_NUM_MAX,
 } sensor_tag_e;
 
@@ -157,6 +165,7 @@ typedef enum
     DEV_SENSOR_VENDOR_LITEON,
     DEV_SENSOR_VENDOR_AMS,
     DEV_SENSOR_VENDOR_CNT_MAXIM,
+    DEV_SENSOR_VENDOR_SENSIRION,
 } vendor_id_e;
 
 typedef enum
@@ -202,8 +211,11 @@ typedef enum
     cm,
     pa,
     permillage,
+    percentage,
     bpm,
     dCelsius,
+    ohm,
+    pascal,
 } value_unit_e;
 
 typedef enum {
@@ -325,6 +337,26 @@ typedef struct _dev_gs_data_t
     uint64_t    timestamp;
     gs_type_e   gs_type;
 } gs_data_t;
+
+typedef struct _dev_gr_data_t
+{
+    uint64_t    timestamp;
+    uint32_t    gr;
+} gr_data_t;
+
+typedef struct _dev_pm_data_t {
+    uint64_t    timestamp;
+    float mc_1p0;
+    float mc_2p5;
+    float mc_4p0;
+    float mc_10p0;
+    float nc_0p5;
+    float nc_1p0;
+    float nc_2p5;
+    float nc_4p0;
+    float nc_10p0;
+    float typical_particle_size;
+} pm_data_t;
 
 typedef void (*SENSOR_IRQ_CALLBACK)(sensor_tag_e tag);
 typedef struct _dev_sensor_config_t

--- a/device/sensor/sensor.mk
+++ b/device/sensor/sensor.mk
@@ -15,7 +15,11 @@ $(NAME)_SOURCES += \
         drv/drv_temp_humi_sensirion_shtc1.c \
         drv/drv_temp_humi_st_hts221.c \
         drv/drv_mag_st_lis3mdl.c \
-        drv/drv_mag_temp_memsic_mmc3680kj.c
+        drv/drv_mag_temp_memsic_mmc3680kj.c \
+		drv/drv_gr_baro_temp_hum_bosch_bme680/drv_gr_baro_temp_hum_bosch_bme680.c \
+        drv/drv_pm_sensirion_sps30/sensirion_common.c \
+        drv/drv_pm_sensirion_sps30/sps30.c \
+        drv/drv_pm_sensirion_sps30/drv_pm_sensirion_sps30.c 
 
         
 
@@ -44,3 +48,7 @@ GLOBAL_DEFINES      += AOS_SENSOR
 #GLOBAL_DEFINES      += AOS_SENSOR_TEMP_SENSIRION_SHTC1
 #GLOBAL_DEFINES      += AOS_SENSOR_HUMI_SENSIRION_SHTC1
 
+#  * Copyright (C) 2019 X-Cite SA (http://www.x-cite.io)
+#  * Written by Lemmer El Assal (lemmer@x-cite.io)
+#GLOBAL_DEFINES      += AOS_SENSOR_GR_BARO_TEMP_HUM_BOSCH_BME680
+#GLOBAL_DEFINES      += AOS_SENSOR_PM_SENSIRION_SPS30

--- a/platform/mcu/esp32/hal/i2c.c
+++ b/platform/mcu/esp32/hal/i2c.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2015-2018 Alibaba Group Holding Limited
+ * Copyright (C) 2019 X-Cite SA (http://www.x-cite.io)
+ * I2C driver rewritten by Lemmer El Assal (lemmer@x-cite.io)
  */
 
 #include <stdio.h>
@@ -102,7 +104,7 @@ static void i2c_config_ctr(i2c_dev_t * handle,uint32_t clk)
     handle->ctr.scl_force_out = 1;
     handle->ctr.sample_scl_level = 0;
     handle->fifo_conf.nonfifo_en = 0;
-    handle->timeout.tout = cycle * 8;
+    handle->timeout.tout = 32000; //cycle * 8;
     handle->sda_hold.time = half_cycle / 2;
     handle->sda_sample.time = half_cycle / 2;
     handle->scl_low_period.period = half_cycle;
@@ -114,6 +116,7 @@ static void i2c_config_ctr(i2c_dev_t * handle,uint32_t clk)
 
 }
 
+#define bool uint32_t
 
 static int8_t i2c_config_cmd(i2c_dev_t * handle,uint8_t index,uint8_t op_code,uint8_t byte_num,bool ack_en,bool ack_exp,bool ack_val)
 {
@@ -188,7 +191,7 @@ static int8_t i2c_check_status(i2c_dev_t * handle)
 }
 
 
-static int32_t i2c_write_bytes(i2c_dev_t * handle,uint16_t addr,int8_t add_width,uint8_t * buff,uint32_t len,int8_t need_stop)
+static int32_t i2c_write_bytes(i2c_dev_t * handle,uint16_t addr,int8_t add_width,uint8_t * buff,uint32_t len,int8_t need_stop, uint32_t timeout)
 {
     if(NULL == handle || NULL == buff || len == 0) {
         return(-1);
@@ -201,6 +204,7 @@ static int32_t i2c_write_bytes(i2c_dev_t * handle,uint16_t addr,int8_t add_width
     uint16_t send_counts = 0;
     uint16_t packet_size = 0;
     uint16_t send_len = 0;
+    timeout = (APB_CLK_FREQ / 1000)*timeout;
     while(total_size) {
         packet_size = (total_size > 32) ? 32 : total_size;
         send_len = packet_size;
@@ -235,15 +239,16 @@ static int32_t i2c_write_bytes(i2c_dev_t * handle,uint16_t addr,int8_t add_width
             if((need_stop && handle->command[2].done) || !handle->status_reg.bus_busy) {
                 break;
             }
-        } while(krhino_sys_time_get()-start < 20);
+        } while(krhino_sys_time_get()-start < timeout);
     }
 
     return 0;
 
 }
 
+#define I2C_MAX_BULK_SIZE 16
 
-static int32_t i2c_read_bytes(i2c_dev_t * handle,uint16_t addr,int8_t add_width,uint8_t * buff,uint32_t len,int8_t need_stop)
+static int32_t i2c_read_bytes(i2c_dev_t * handle,uint16_t addr,int8_t add_width,uint8_t * buff,uint32_t len,int8_t need_stop, uint32_t timeout)
 {
     if(NULL == handle || NULL == buff || len == 0) {
         return(-1);
@@ -257,55 +262,54 @@ static int32_t i2c_read_bytes(i2c_dev_t * handle,uint16_t addr,int8_t add_width,
     uint8_t currentCmdIdx = 0;
     uint8_t cmd_index = 0;
     uint16_t dev_addr = (addr << 1) | 1;
+    timeout = (APB_CLK_FREQ / 1000)*timeout;
     i2c_start_prepare(handle);
     i2c_config_cmd(handle,cmd_index,I2C_CMD_RSTART,0,false,false,false);
     cmd_index = (cmd_index+1)%I2C_CMD_MAX;
     i2c_send_addr(handle,0,dev_addr,add_width);
     i2c_config_cmd(handle,cmd_index,I2C_CMD_WRITE,add_width?2:1,true,false,false);
     cmd_index = (cmd_index+1)%I2C_CMD_MAX;
-    nextCmdCount = cmd_index;
     handle->ctr.trans_start = 1;
-    while(is_run) {
-        uint32_t startAt = krhino_sys_time_get();
-        do {
 
-            if(0 != i2c_check_status(handle)) {
-                return (-1);
-            }
-
-            if(handle->command[currentCmdIdx].done) {
-                nextCmdCount--;
-                if (handle->command[currentCmdIdx].op_code == I2C_CMD_READ) {
-                    if(currentCmdIdx >= 2) {
-                        buff[index++] = handle->fifo_data.val & 0xFF;
-                    }
-                    handle->fifo_conf.tx_fifo_rst = 1;
-                    handle->fifo_conf.tx_fifo_rst = 0;
-                    handle->fifo_conf.rx_fifo_rst = 1;
-                    handle->fifo_conf.rx_fifo_rst = 0;
-                } else if (handle->command[currentCmdIdx].op_code == I2C_CMD_STOP) {
-                    is_run = 0;
-                    break;
-                }
-                currentCmdIdx = (currentCmdIdx+1)%I2C_CMD_MAX;
-                if(nextCmdCount < 2) {
-                    if(len > 0) {
-                        i2c_config_cmd(handle, cmd_index, I2C_CMD_READ, 1, false, false, (len==1));
-                        cmd_index = (cmd_index+1)%I2C_CMD_MAX;
-                        nextCmdCount++;
-                        len -= 1;
-                    } else {
-                        i2c_config_cmd(handle, cmd_index, I2C_CMD_STOP, 0, false, false, false);
-                        cmd_index = (cmd_index+1)%I2C_CMD_MAX;
-                        nextCmdCount++;
-                    }
-                }
-                break;
-            }
-        } while(krhino_sys_time_get() - startAt < 20);
+    uint32_t rcv_len = len;
+    while(rcv_len) {
+        if(rcv_len > I2C_MAX_BULK_SIZE) {
+            i2c_config_cmd(handle, cmd_index, I2C_CMD_READ, I2C_MAX_BULK_SIZE, true, false, false);
+            rcv_len -= I2C_MAX_BULK_SIZE;
+        } else if(rcv_len > 1) {
+            i2c_config_cmd(handle, cmd_index, I2C_CMD_READ, rcv_len-1, true, false, false);
+            rcv_len = 1;
+        } else {
+            i2c_config_cmd(handle, cmd_index, I2C_CMD_READ, 1, true, false, true);
+            rcv_len = 0;
+        }
+        cmd_index = (cmd_index+1)%I2C_CMD_MAX;
     }
 
-    return (0);
+    i2c_config_cmd(handle, cmd_index, I2C_CMD_STOP, 0, false, false, false);
+    cmd_index = (cmd_index+1)%I2C_CMD_MAX;
+
+    uint32_t startAt = krhino_sys_time_get();
+    do {
+        if(i2c_check_status(handle))
+            return -1;
+        if(handle->command[currentCmdIdx].done) {
+            if (handle->command[currentCmdIdx].op_code == I2C_CMD_READ) {
+                for(uint32_t i=0; i<handle->command[currentCmdIdx].byte_num; i++)
+                    buff[index++] = handle->fifo_data.val & 0xFF;
+                // Uncomment lines below if you encounter problems. -Lemmer
+                // handle->fifo_conf.tx_fifo_rst = 1;
+                // handle->fifo_conf.tx_fifo_rst = 0;
+                // handle->fifo_conf.rx_fifo_rst = 1;
+                // handle->fifo_conf.rx_fifo_rst = 0;
+            }
+            currentCmdIdx++;
+        }
+    } while((krhino_sys_time_get() - startAt < timeout) && (currentCmdIdx < cmd_index));
+
+    if(krhino_sys_time_get() - startAt < timeout)
+        return 0;
+    return -1;
 }
 
 
@@ -324,26 +328,33 @@ int32_t hal_i2c_init(aos_i2c_dev_t *i2c)
 
 int32_t hal_i2c_master_send(aos_i2c_dev_t *i2c, uint16_t dev_addr, const uint8_t *data,uint16_t size, uint32_t timeout)
 {
-    int32_t ret = 0;
     if(NULL == i2c || (I2C_NUM_0 != i2c->port)&&(I2C_NUM_1 != i2c->port)) {
         return (-1);
     }
     i2c_resource_t * resource = &g_dev[i2c->port];
-    uint16_t addr = dev_addr >> 1;
-    i2c_write_bytes(resource->dev,addr,i2c->config.address_width == I2C_MEM_ADDR_SIZE_16BIT,data,size,0);
+    int ret = i2c_write_bytes(resource->dev,dev_addr,i2c->config.address_width == I2C_MEM_ADDR_SIZE_16BIT,data,size,1,timeout);
 
     return ret;
 }
 
 int32_t hal_i2c_master_recv(aos_i2c_dev_t *i2c, uint16_t dev_addr, uint8_t *data,uint16_t size, uint32_t timeout)
 {
-    int32_t ret = 0;
     if(NULL == i2c || (I2C_NUM_0 != i2c->port)&&(I2C_NUM_1 != i2c->port)) {
         return (-1);
     }
     i2c_resource_t * resource = &g_dev[i2c->port];
-    uint16_t addr = dev_addr >> 1;
-    i2c_read_bytes(resource->dev,addr,i2c->config.address_width == I2C_MEM_ADDR_SIZE_16BIT,data,size,0);
+    int32_t ret = i2c_read_bytes(resource->dev,dev_addr,i2c->config.address_width == I2C_MEM_ADDR_SIZE_16BIT,data,size,1,timeout);
+
+    return ret;
+}
+
+int32_t hal_i2c_master_recv_bulk(aos_i2c_dev_t *i2c, uint16_t dev_addr, uint8_t *data,uint16_t size, uint32_t timeout)
+{
+    if(NULL == i2c || (I2C_NUM_0 != i2c->port)&&(I2C_NUM_1 != i2c->port)) {
+        return (-1);
+    }
+    i2c_resource_t * resource = &g_dev[i2c->port];
+    int32_t ret = i2c_read_bytes(resource->dev,dev_addr,i2c->config.address_width == I2C_MEM_ADDR_SIZE_16BIT,data,size,1,timeout);
 
     return ret;
 }
@@ -366,17 +377,23 @@ int32_t hal_i2c_mem_write(aos_i2c_dev_t *i2c, uint16_t dev_addr, uint16_t mem_ad
                           uint16_t mem_addr_size, const uint8_t *data, uint16_t size,
                           uint32_t timeout)
 {
-    int32_t ret = 0;
-
-    return ret;
+    uint8_t *temp = malloc(mem_addr_size+size);
+    memcpy(temp, &mem_addr, mem_addr_size);
+    if(size)
+        memcpy(temp+mem_addr_size, data, size);
+    int32_t res = hal_i2c_master_send(i2c, dev_addr, temp, size+mem_addr_size, timeout);
+    free(temp);
+    return res;
 }
 
 int32_t hal_i2c_mem_read(aos_i2c_dev_t *i2c, uint16_t dev_addr, uint16_t mem_addr,
                          uint16_t mem_addr_size, uint8_t *data, uint16_t size,
                          uint32_t timeout)
 {
-    int32_t ret = 0;
-
+    i2c_resource_t * resource = &g_dev[i2c->port];
+    int32_t ret = i2c_write_bytes(resource->dev,dev_addr,i2c->config.address_width == I2C_MEM_ADDR_SIZE_16BIT,(uint8_t *) &mem_addr,mem_addr_size,0,timeout);
+    if(ret == 0)
+        return hal_i2c_master_recv(i2c, dev_addr, data, size, timeout);
     return ret;
 }
 
@@ -386,5 +403,3 @@ int32_t hal_i2c_finalize(aos_i2c_dev_t *i2c)
 
     return ret;
 }
-
-


### PR DESCRIPTION
- Issues with I2C HAL for ESP32 have been fixed
- Added native sensor support for Sensirion SPS30 (dev_pm_path)
- Added native sensor support for Bosch BME680 (dev_temp_path, dev_humi_path, dev_baro_path, dev_gas_resistance_path)