### PR TITLE
fix printf issue in GCC environment

### DIFF
--- a/utility/libc/newlib_stub.c
+++ b/utility/libc/newlib_stub.c
@@ -155,13 +155,13 @@ _ssize_t _write_r(struct _reent *ptr, int fd, const void *buf, size_t nbytes)
 #ifdef WITH_LWIP_TELNETD
                 TelnetWrite('\r');
 #endif
-                hal_uart_send(&uart_stdio, (void *)"\r", 1, 0);
+                hal_uart_send(&uart_stdio, (void *)"\r", 1, AOS_WAIT_FOREVER);
             }
 
 #ifdef WITH_LWIP_TELNETD
             TelnetWrite(*tmp);
 #endif
-            hal_uart_send(&uart_stdio, (void *)tmp, 1, 0);
+            hal_uart_send(&uart_stdio, (void *)tmp, 1, AOS_WAIT_FOREVER);
             tmp++;
         }
 


### PR DESCRIPTION
使用GCC编译器，printf会调用 _write_r函数，_write_r调用hal_uart_send, hul_uart_send的timeout参数不能设置为0，此处改为AOS_WAIT_FOREVER