### PR TITLE
usart isr handler solved

### DIFF
--- a/platform/mcu/stm32f4xx_cube/hal/hal_uart_stm32f4.c
+++ b/platform/mcu/stm32f4xx_cube/hal/hal_uart_stm32f4.c
@@ -126,7 +126,6 @@ void HAL_UART_IRQHandler_User(UART_HandleTypeDef *huart)
     if(((isrflags & USART_SR_ORE) != RESET) && ((cr3its & USART_CR3_EIE) != RESET))
     { 
       huart->ErrorCode |= HAL_UART_ERROR_ORE;
-      __HAL_UART_CLEAR_OREFLAG(huart);
     }
     __HAL_UART_CLEAR_PEFLAG(huart);
     return;

--- a/platform/mcu/stm32f4xx_cube/hal/hal_uart_stm32f4.c
+++ b/platform/mcu/stm32f4xx_cube/hal/hal_uart_stm32f4.c
@@ -126,7 +126,9 @@ void HAL_UART_IRQHandler_User(UART_HandleTypeDef *huart)
     if(((isrflags & USART_SR_ORE) != RESET) && ((cr3its & USART_CR3_EIE) != RESET))
     { 
       huart->ErrorCode |= HAL_UART_ERROR_ORE;
+      __HAL_UART_CLEAR_OREFLAG(huart);
     }
+    __HAL_UART_CLEAR_PEFLAG(huart);
     return;
   } /* End if some error occurs */
 


### PR DESCRIPTION
when overrun or other errors occur, usart interrupt handler is enter again and again. adding a line will solve it.