### PR TITLE
fix gpio pin read error

### DIFF
--- a/platform/mcu/stm32f4xx_cube/hal/hal_gpio_stm32f4.c
+++ b/platform/mcu/stm32f4xx_cube/hal/hal_gpio_stm32f4.c
@@ -136,7 +136,7 @@ int32_t hal_gpio_input_get(gpio_dev_t *gpio, uint32_t *value)
 
     ret = get_gpio_group(gpio, &GPIOx);
     if (ret == 0) {
-        pin = gpio->port % PINS_IN_GROUP;
+         pin = get_gpio_pin(gpio->port);
         *value = HAL_GPIO_ReadPin(GPIOx, pin);
     };
 


### PR DESCRIPTION
pin shall be get through function get_gpio_pin, rather than raw calculation.