### PR TITLE
fixed wrong sensor device paths

### DIFF
--- a/app/example/dk/dk_gui/sensor_display.c
+++ b/app/example/dk/dk_gui/sensor_display.c
@@ -144,27 +144,27 @@ static void littlevgl_refresh_task(void *arg)
 void app_init(void)
 {
     /* open acc sensor */
-    fd_acc = aos_open(dev_acc_path, O_RDWR);
+    fd_acc = aos_open(DEV_ACC_PATH(0), O_RDWR);
 
     if (fd_acc < 0) {
         printf("acc sensor open failed !\n");
     }
 
     /* open temp sensor */
-    fd_temp = aos_open(dev_temp_path, O_RDWR);
+    fd_temp = aos_open(DEV_TEMP_PATH(0), O_RDWR);
 
     if (fd_temp < 0) {
         printf("temp sensor open failed !\n");
     }
 
     /* open temp sensor */
-    fd_humi = aos_open(dev_humi_path, O_RDWR);
+    fd_humi = aos_open(DEV_HUMI_PATH(0), O_RDWR);
 
     if (fd_humi < 0) {
         printf("humi sensor open failed !\n");
     }
 
-    fd_baro = aos_open(dev_baro_path, O_RDWR);
+    fd_baro = aos_open(DEV_BARO_PATH(0), O_RDWR);
 
     if (fd_baro < 0) {
         printf("baro sensor open failed !\n");

--- a/include/sensor/sensor.h
+++ b/include/sensor/sensor.h
@@ -127,6 +127,7 @@ typedef enum {
 #define MAGNETOMETER_UNIT_FACTOR  1000    /* mGauss */
 #define GYROSCOPE_UNIT_FACTOR     1000000 /* uDPS */
 
+#define DEV_ACC_PATH(x)   dev_acc_path "/" ToString(x)
 #define DEV_HUMI_PATH(x)  dev_humi_path "/" ToString(x)
 #define DEV_TEMP_PATH(x)  dev_temp_path "/" ToString(x)
 #define DEV_NOISE_PATH(x) dev_noise_path "/" ToString(x)


### PR DESCRIPTION
device paths of sensors always end with sensor instance id as code in function sensor_create_obj shows
vim drivers/sensor/hal/sensor_hal.c +203

ret = snprintf(g_sensor_path[index], SENSOR_NAME_LEN, "%s/%d", sensor->path, sensor->instance);

before patch:
<img width="404" alt="before_patch_failed" src="https://user-images.githubusercontent.com/12431276/57965938-eb799f00-797d-11e9-98aa-c64f24af68ec.png">

after patch:
<img width="401" alt="after_patch_success" src="https://user-images.githubusercontent.com/12431276/57965940-f3394380-797d-11e9-9476-c2a55f4dfb01.png">
