### PR TITLE
Developerkit V13/UART4 support

### DIFF
--- a/board/developerkit/Inc/main.h
+++ b/board/developerkit/Inc/main.h
@@ -52,14 +52,10 @@
 
 #define SIM_DET_Pin GPIO_PIN_2
 #define SIM_DET_GPIO_Port GPIOE
-#define GS_LED_Pin GPIO_PIN_3
-#define GS_LED_GPIO_Port GPIOE
+#define LED_2_Pin GPIO_PIN_3
+#define LED_2_GPIO_Port GPIOE
 #define PCIE_RST_Pin GPIO_PIN_13
 #define PCIE_RST_GPIO_Port GPIOC
-#define SECURE_IO_Pin GPIO_PIN_0
-#define SECURE_IO_GPIO_Port GPIOA
-#define SECURE_RST_Pin GPIO_PIN_1
-#define SECURE_RST_GPIO_Port GPIOA
 #define LCD_DCX_Pin GPIO_PIN_6
 #define LCD_DCX_GPIO_Port GPIOA
 #define WIFI_RST_Pin GPIO_PIN_0
@@ -86,15 +82,11 @@
 #define KEY_2_Pin GPIO_PIN_14
 #define KEY_2_GPIO_Port GPIOE
 #define KEY_2_EXTI_IRQn EXTI15_10_IRQn
-#define SECURE_CLK_Pin GPIO_PIN_15
-#define SECURE_CLK_GPIO_Port GPIOE
-#define HTS_LED_Pin GPIO_PIN_11
-#define HTS_LED_GPIO_Port GPIOD
-#define PS_LED_Pin GPIO_PIN_14
-#define PS_LED_GPIO_Port GPIOD
-#define COMPASS_LED_Pin GPIO_PIN_15
-#define COMPASS_LED_GPIO_Port GPIOD
-#define CAM_MCLK_Pin GPIO_PIN_8
+#define SECURE_RST_Pin GPIO_PIN_15
+#define SECURE_RST_GPIO_Port GPIOE
+#define LED_3_Pin GPIO_PIN_15
+#define LED_3_GPIO_Port GPIOD
+#define CAM_MCLK_Pin GPIO_PIN_9
 #define CAM_MCLK_GPIO_Port GPIOA
 #define ALS_INT_Pin GPIO_PIN_15
 #define ALS_INT_GPIO_Port GPIOA
@@ -105,12 +97,10 @@
 #define AUDIO_CTL_GPIO_Port GPIOD
 #define AUDIO_RST_Pin GPIO_PIN_6
 #define AUDIO_RST_GPIO_Port GPIOD
-#define ZIGBEE_RST_Pin GPIO_PIN_7
-#define ZIGBEE_RST_GPIO_Port GPIOD
 #define USB_PCIE_SW_Pin GPIO_PIN_5
 #define USB_PCIE_SW_GPIO_Port GPIOB
-#define ALS_LED_Pin GPIO_PIN_6
-#define ALS_LED_GPIO_Port GPIOB
+#define LED_1_Pin GPIO_PIN_6
+#define LED_1_GPIO_Port GPIOB
 #define CAM_RST_Pin GPIO_PIN_8
 #define CAM_RST_GPIO_Port GPIOB
 

--- a/board/developerkit/Inc/usart.h
+++ b/board/developerkit/Inc/usart.h
@@ -51,19 +51,11 @@
 
 /* USER CODE END Includes */
 
-extern UART_HandleTypeDef hlpuart1;
-extern UART_HandleTypeDef huart2;
-extern UART_HandleTypeDef huart3;
-
 /* USER CODE BEGIN Private defines */
 
 /* USER CODE END Private defines */
 
 extern void _Error_Handler(char *, int);
-
-void MX_LPUART1_UART_Init(void);
-void MX_USART2_UART_Init(void);
-void MX_USART3_UART_Init(void);
 
 /* USER CODE BEGIN Prototypes */
 

--- a/board/developerkit/Src/gpio.c
+++ b/board/developerkit/Src/gpio.c
@@ -66,7 +66,7 @@
 void MX_GPIO_Init(void)
 {
 
-  GPIO_InitTypeDef GPIO_InitStruct;
+  GPIO_InitTypeDef GPIO_InitStruct = {0};
 
   /* GPIO Ports Clock Enable */
   __HAL_RCC_GPIOE_CLK_ENABLE();
@@ -77,27 +77,20 @@ void MX_GPIO_Init(void)
   __HAL_RCC_GPIOD_CLK_ENABLE();
 
   /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(GPIOE, GS_LED_Pin|CAM_PD_Pin|SECURE_CLK_Pin, GPIO_PIN_SET);
+  HAL_GPIO_WritePin(GPIOE, LED_2_Pin|LCD_PWR_Pin|CAM_PD_Pin|SECURE_RST_Pin, GPIO_PIN_RESET);
 
   /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(PCIE_RST_GPIO_Port, PCIE_RST_Pin, GPIO_PIN_SET);
+  HAL_GPIO_WritePin(PCIE_RST_GPIO_Port, PCIE_RST_Pin, GPIO_PIN_RESET);
 
   /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(GPIOA, SECURE_IO_Pin|SECURE_RST_Pin|LCD_DCX_Pin, GPIO_PIN_SET);
+  HAL_GPIO_WritePin(LCD_DCX_GPIO_Port, LCD_DCX_Pin, GPIO_PIN_RESET);
 
   /*Configure GPIO pin Output Level */
   HAL_GPIO_WritePin(GPIOB, WIFI_RST_Pin|WIFI_WU_Pin|LCD_RST_Pin|USB_PCIE_SW_Pin 
-                          |ALS_LED_Pin|CAM_RST_Pin, GPIO_PIN_SET);
+                          |LED_1_Pin|CAM_RST_Pin, GPIO_PIN_RESET);
 
   /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(LCD_PWR_GPIO_Port, LCD_PWR_Pin, GPIO_PIN_RESET);
-
-  /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(GPIOD, HTS_LED_Pin|PS_LED_Pin|COMPASS_LED_Pin|AUDIO_WU_Pin 
-                          |AUDIO_RST_Pin|ZIGBEE_RST_Pin, GPIO_PIN_SET);
-
-  /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(AUDIO_CTL_GPIO_Port, AUDIO_CTL_Pin, GPIO_PIN_RESET);
+  HAL_GPIO_WritePin(GPIOD, LED_3_Pin|AUDIO_WU_Pin|AUDIO_CTL_Pin|AUDIO_RST_Pin, GPIO_PIN_RESET);
 
   /*Configure GPIO pin : PtPin */
   GPIO_InitStruct.Pin = SIM_DET_Pin;
@@ -106,7 +99,7 @@ void MX_GPIO_Init(void)
   HAL_GPIO_Init(SIM_DET_GPIO_Port, &GPIO_InitStruct);
 
   /*Configure GPIO pins : PEPin PEPin PEPin PEPin */
-  GPIO_InitStruct.Pin = GS_LED_Pin|LCD_PWR_Pin|CAM_PD_Pin|SECURE_CLK_Pin;
+  GPIO_InitStruct.Pin = LED_2_Pin|LCD_PWR_Pin|CAM_PD_Pin|SECURE_RST_Pin;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
@@ -119,17 +112,17 @@ void MX_GPIO_Init(void)
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   HAL_GPIO_Init(PCIE_RST_GPIO_Port, &GPIO_InitStruct);
 
-  /*Configure GPIO pins : PAPin PAPin PAPin */
-  GPIO_InitStruct.Pin = SECURE_IO_Pin|SECURE_RST_Pin|LCD_DCX_Pin;
+  /*Configure GPIO pin : PtPin */
+  GPIO_InitStruct.Pin = LCD_DCX_Pin;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+  HAL_GPIO_Init(LCD_DCX_GPIO_Port, &GPIO_InitStruct);
 
   /*Configure GPIO pins : PBPin PBPin PBPin PBPin 
                            PBPin PBPin */
   GPIO_InitStruct.Pin = WIFI_RST_Pin|WIFI_WU_Pin|LCD_RST_Pin|USB_PCIE_SW_Pin 
-                          |ALS_LED_Pin|CAM_RST_Pin;
+                          |LED_1_Pin|CAM_RST_Pin;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
@@ -141,22 +134,20 @@ void MX_GPIO_Init(void)
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   HAL_GPIO_Init(GPIOE, &GPIO_InitStruct);
 
-  /*Configure GPIO pins : PDPin PDPin PDPin PDPin 
-                           PDPin PDPin PDPin */
-  GPIO_InitStruct.Pin = HTS_LED_Pin|PS_LED_Pin|COMPASS_LED_Pin|AUDIO_WU_Pin 
-                          |AUDIO_CTL_Pin|AUDIO_RST_Pin|ZIGBEE_RST_Pin;
+  /*Configure GPIO pins : PDPin PDPin PDPin PDPin */
+  GPIO_InitStruct.Pin = LED_3_Pin|AUDIO_WU_Pin|AUDIO_CTL_Pin|AUDIO_RST_Pin;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-  /*Configure GPIO pin : PtPin */
-  GPIO_InitStruct.Pin = CAM_MCLK_Pin;
+  /*Configure GPIO pin : PA8 */
+  GPIO_InitStruct.Pin = GPIO_PIN_8;
   GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   GPIO_InitStruct.Alternate = GPIO_AF0_MCO;
-  HAL_GPIO_Init(CAM_MCLK_GPIO_Port, &GPIO_InitStruct);
+  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
   /*Configure GPIO pins : PA10 PA11 PA12 */
   GPIO_InitStruct.Pin = GPIO_PIN_10|GPIO_PIN_11|GPIO_PIN_12;
@@ -176,7 +167,7 @@ void MX_GPIO_Init(void)
   GPIO_InitStruct.Pin = GPIO_PIN_9;
   GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
   GPIO_InitStruct.Alternate = GPIO_AF1_IR;
   HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 

--- a/board/developerkit/Src/main.c
+++ b/board/developerkit/Src/main.c
@@ -194,12 +194,14 @@ void SystemClock_Config(void)
   }
 
   PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART2|RCC_PERIPHCLK_USART3
-                              |RCC_PERIPHCLK_LPUART1|RCC_PERIPHCLK_SAI2
-                              |RCC_PERIPHCLK_I2C2|RCC_PERIPHCLK_I2C3
-                              |RCC_PERIPHCLK_I2C4|RCC_PERIPHCLK_USB
-                              |RCC_PERIPHCLK_SDMMC1|RCC_PERIPHCLK_ADC;
+                              |RCC_PERIPHCLK_UART4|RCC_PERIPHCLK_LPUART1
+                              |RCC_PERIPHCLK_SAI2|RCC_PERIPHCLK_I2C2
+                              |RCC_PERIPHCLK_I2C3|RCC_PERIPHCLK_I2C4
+                              |RCC_PERIPHCLK_USB|RCC_PERIPHCLK_SDMMC1
+                              |RCC_PERIPHCLK_ADC;
   PeriphClkInit.Usart2ClockSelection = RCC_USART2CLKSOURCE_PCLK1;
   PeriphClkInit.Usart3ClockSelection = RCC_USART3CLKSOURCE_PCLK1;
+  PeriphClkInit.Uart4ClockSelection = RCC_UART4CLKSOURCE_PCLK1;
   PeriphClkInit.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_PCLK1;
   PeriphClkInit.I2c2ClockSelection = RCC_I2C2CLKSOURCE_PCLK1;
   PeriphClkInit.I2c3ClockSelection = RCC_I2C3CLKSOURCE_PCLK1;

--- a/board/developerkit/Src/usart.c
+++ b/board/developerkit/Src/usart.c
@@ -47,81 +47,10 @@
 
 /* USER CODE END 0 */
 
-UART_HandleTypeDef hlpuart1;
-UART_HandleTypeDef huart2;
-UART_HandleTypeDef huart3;
-DMA_HandleTypeDef hdma_usart2_rx;
-DMA_HandleTypeDef hdma_usart2_tx;
-DMA_HandleTypeDef hdma_usart3_rx;
-DMA_HandleTypeDef hdma_usart3_tx;
-
-/* LPUART1 init function */
-
-void MX_LPUART1_UART_Init(void)
-{
-
-  hlpuart1.Instance = LPUART1;
-  hlpuart1.Init.BaudRate = 115200;
-  hlpuart1.Init.WordLength = UART_WORDLENGTH_8B;
-  hlpuart1.Init.StopBits = UART_STOPBITS_1;
-  hlpuart1.Init.Parity = UART_PARITY_NONE;
-  hlpuart1.Init.Mode = UART_MODE_TX_RX;
-  hlpuart1.Init.HwFlowCtl = UART_HWCONTROL_NONE;
-  hlpuart1.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
-  hlpuart1.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
-  if (HAL_UART_Init(&hlpuart1) != HAL_OK)
-  {
-    _Error_Handler(__FILE__, __LINE__);
-  }
-
-}
-/* USART2 init function */
-
-void MX_USART2_UART_Init(void)
-{
-
-  huart2.Instance = USART2;
-  huart2.Init.BaudRate = 115200;
-  huart2.Init.WordLength = UART_WORDLENGTH_8B;
-  huart2.Init.StopBits = UART_STOPBITS_1;
-  huart2.Init.Parity = UART_PARITY_NONE;
-  huart2.Init.Mode = UART_MODE_TX_RX;
-  huart2.Init.HwFlowCtl = UART_HWCONTROL_NONE;
-  huart2.Init.OverSampling = UART_OVERSAMPLING_16;
-  huart2.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
-  huart2.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
-  if (HAL_UART_Init(&huart2) != HAL_OK)
-  {
-    _Error_Handler(__FILE__, __LINE__);
-  }
-
-}
-/* USART3 init function */
-
-void MX_USART3_UART_Init(void)
-{
-
-  huart3.Instance = USART3;
-  huart3.Init.BaudRate = 115200;
-  huart3.Init.WordLength = UART_WORDLENGTH_8B;
-  huart3.Init.StopBits = UART_STOPBITS_1;
-  huart3.Init.Parity = UART_PARITY_NONE;
-  huart3.Init.Mode = UART_MODE_TX_RX;
-  huart3.Init.HwFlowCtl = UART_HWCONTROL_NONE;
-  huart3.Init.OverSampling = UART_OVERSAMPLING_16;
-  huart3.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
-  huart3.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
-  if (HAL_UART_Init(&huart3) != HAL_OK)
-  {
-    _Error_Handler(__FILE__, __LINE__);
-  }
-
-}
-
 void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
 {
 
-  GPIO_InitTypeDef GPIO_InitStruct;
+  GPIO_InitTypeDef GPIO_InitStruct = {0};
   if(uartHandle->Instance==LPUART1)
   {
   /* USER CODE BEGIN LPUART1_MspInit 0 */
@@ -130,6 +59,7 @@ void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
     /* LPUART1 clock enable */
     __HAL_RCC_LPUART1_CLK_ENABLE();
   
+    __HAL_RCC_GPIOB_CLK_ENABLE();
     /**LPUART1 GPIO Configuration    
     PB10     ------> LPUART1_RX
     PB11     ------> LPUART1_TX 
@@ -167,47 +97,39 @@ void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
     GPIO_InitStruct.Alternate = GPIO_AF7_USART2;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-    /* USART2 DMA Init */
-    /* USART2_RX Init */
-    hdma_usart2_rx.Instance = DMA1_Channel6;
-    hdma_usart2_rx.Init.Request = DMA_REQUEST_2;
-    hdma_usart2_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
-    hdma_usart2_rx.Init.PeriphInc = DMA_PINC_DISABLE;
-    hdma_usart2_rx.Init.MemInc = DMA_MINC_ENABLE;
-    hdma_usart2_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    hdma_usart2_rx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_usart2_rx.Init.Mode = DMA_NORMAL;
-    hdma_usart2_rx.Init.Priority = DMA_PRIORITY_LOW;
-    if (HAL_DMA_Init(&hdma_usart2_rx) != HAL_OK)
-    {
-      _Error_Handler(__FILE__, __LINE__);
-    }
-
-    __HAL_LINKDMA(uartHandle,hdmarx,hdma_usart2_rx);
-
-    /* USART2_TX Init */
-    hdma_usart2_tx.Instance = DMA1_Channel7;
-    hdma_usart2_tx.Init.Request = DMA_REQUEST_2;
-    hdma_usart2_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
-    hdma_usart2_tx.Init.PeriphInc = DMA_PINC_DISABLE;
-    hdma_usart2_tx.Init.MemInc = DMA_MINC_ENABLE;
-    hdma_usart2_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    hdma_usart2_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_usart2_tx.Init.Mode = DMA_NORMAL;
-    hdma_usart2_tx.Init.Priority = DMA_PRIORITY_LOW;
-    if (HAL_DMA_Init(&hdma_usart2_tx) != HAL_OK)
-    {
-      _Error_Handler(__FILE__, __LINE__);
-    }
-
-    __HAL_LINKDMA(uartHandle,hdmatx,hdma_usart2_tx);
-
     /* USART2 interrupt Init */
     HAL_NVIC_SetPriority(USART2_IRQn, 0, 0);
     HAL_NVIC_EnableIRQ(USART2_IRQn);
   /* USER CODE BEGIN USART2_MspInit 1 */
 
   /* USER CODE END USART2_MspInit 1 */
+  }
+  else if(uartHandle->Instance==UART4)
+  {
+  /* USER CODE BEGIN UART4_MspInit 0 */
+
+  /* USER CODE END UART4_MspInit 0 */
+    /* UART4 clock enable */
+    __HAL_RCC_UART4_CLK_ENABLE();
+  
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    /**UART4 GPIO Configuration    
+    PA0     ------> UART4_TX
+    PA1     ------> UART4_RX 
+    */
+    GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_1;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+    GPIO_InitStruct.Alternate = GPIO_AF8_UART4;
+    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+    /* UART4 interrupt Init */
+    HAL_NVIC_SetPriority(UART4_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(UART4_IRQn);
+  /* USER CODE BEGIN UART4_MspInit 1 */
+
+  /* USER CODE END UART4_MspInit 1 */
   }
   else if(uartHandle->Instance==USART3)
   {
@@ -217,6 +139,7 @@ void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
     /* USART3 clock enable */
     __HAL_RCC_USART3_CLK_ENABLE();
   
+    __HAL_RCC_GPIOC_CLK_ENABLE();
     /**USART3 GPIO Configuration    
     PC4     ------> USART3_TX
     PC5     ------> USART3_RX 
@@ -227,41 +150,6 @@ void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
     GPIO_InitStruct.Alternate = GPIO_AF7_USART3;
     HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
-    /* USART3 DMA Init */
-    /* USART3_RX Init */
-    hdma_usart3_rx.Instance = DMA1_Channel3;
-    hdma_usart3_rx.Init.Request = DMA_REQUEST_2;
-    hdma_usart3_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
-    hdma_usart3_rx.Init.PeriphInc = DMA_PINC_DISABLE;
-    hdma_usart3_rx.Init.MemInc = DMA_MINC_ENABLE;
-    hdma_usart3_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    hdma_usart3_rx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_usart3_rx.Init.Mode = DMA_NORMAL;
-    hdma_usart3_rx.Init.Priority = DMA_PRIORITY_LOW;
-    if (HAL_DMA_Init(&hdma_usart3_rx) != HAL_OK)
-    {
-      _Error_Handler(__FILE__, __LINE__);
-    }
-
-    __HAL_LINKDMA(uartHandle,hdmarx,hdma_usart3_rx);
-
-    /* USART3_TX Init */
-    hdma_usart3_tx.Instance = DMA1_Channel2;
-    hdma_usart3_tx.Init.Request = DMA_REQUEST_2;
-    hdma_usart3_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
-    hdma_usart3_tx.Init.PeriphInc = DMA_PINC_DISABLE;
-    hdma_usart3_tx.Init.MemInc = DMA_MINC_ENABLE;
-    hdma_usart3_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    hdma_usart3_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_usart3_tx.Init.Mode = DMA_NORMAL;
-    hdma_usart3_tx.Init.Priority = DMA_PRIORITY_LOW;
-    if (HAL_DMA_Init(&hdma_usart3_tx) != HAL_OK)
-    {
-      _Error_Handler(__FILE__, __LINE__);
-    }
-
-    __HAL_LINKDMA(uartHandle,hdmatx,hdma_usart3_tx);
 
     /* USART3 interrupt Init */
     HAL_NVIC_SetPriority(USART3_IRQn, 0, 0);
@@ -295,29 +183,25 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* uartHandle)
 
   /* USER CODE END LPUART1_MspDeInit 1 */
   }
-  else if(uartHandle->Instance==USART2)
+  else if(uartHandle->Instance==UART4)
   {
-  /* USER CODE BEGIN USART2_MspDeInit 0 */
+  /* USER CODE BEGIN UART4_MspDeInit 0 */
 
-  /* USER CODE END USART2_MspDeInit 0 */
+  /* USER CODE END UART4_MspDeInit 0 */
     /* Peripheral clock disable */
-    __HAL_RCC_USART2_CLK_DISABLE();
+    __HAL_RCC_UART4_CLK_DISABLE();
   
-    /**USART2 GPIO Configuration    
-    PA2     ------> USART2_TX
-    PA3     ------> USART2_RX 
+    /**UART4 GPIO Configuration    
+    PA0     ------> UART4_TX
+    PA1     ------> UART4_RX 
     */
-    HAL_GPIO_DeInit(GPIOA, GPIO_PIN_2|GPIO_PIN_3);
+    HAL_GPIO_DeInit(GPIOA, GPIO_PIN_0|GPIO_PIN_1);
 
-    /* USART2 DMA DeInit */
-    HAL_DMA_DeInit(uartHandle->hdmarx);
-    HAL_DMA_DeInit(uartHandle->hdmatx);
+    /* UART4 interrupt Deinit */
+    HAL_NVIC_DisableIRQ(UART4_IRQn);
+  /* USER CODE BEGIN UART4_MspDeInit 1 */
 
-    /* USART2 interrupt Deinit */
-    HAL_NVIC_DisableIRQ(USART2_IRQn);
-  /* USER CODE BEGIN USART2_MspDeInit 1 */
-
-  /* USER CODE END USART2_MspDeInit 1 */
+  /* USER CODE END UART4_MspDeInit 1 */
   }
   else if(uartHandle->Instance==USART3)
   {
@@ -333,17 +217,13 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* uartHandle)
     */
     HAL_GPIO_DeInit(GPIOC, GPIO_PIN_4|GPIO_PIN_5);
 
-    /* USART3 DMA DeInit */
-    HAL_DMA_DeInit(uartHandle->hdmarx);
-    HAL_DMA_DeInit(uartHandle->hdmatx);
-
     /* USART3 interrupt Deinit */
     HAL_NVIC_DisableIRQ(USART3_IRQn);
   /* USER CODE BEGIN USART3_MspDeInit 1 */
 
   /* USER CODE END USART3_MspDeInit 1 */
   }
-} 
+}
 
 /* USER CODE BEGIN 1 */
 

--- a/board/developerkit/aos.mk
+++ b/board/developerkit/aos.mk
@@ -164,6 +164,10 @@ endif
 endif
 endif
 
+ifeq ($(hwver),12)
+GLOBAL_DEFINES += DEVKIT_HWV12
+endif
+
 AOS_NETWORK_SAL ?= y
 ifeq (y,$(AOS_NETWORK_SAL))
 $(NAME)_COMPONENTS += sal netmgr

--- a/board/developerkit/aos/soc_init.h
+++ b/board/developerkit/aos/soc_init.h
@@ -60,39 +60,44 @@
 /* Private define ------------------------------------------------------------*/
 
 typedef enum {
-    GPIO_ALS_INT,
-    GPIO_AUDIO_CTL,
-    GPIO_AUDIO_RST,
-    GPIO_AUDIO_WU,
-    GPIO_CAM_PD,
-    GPIO_CAM_RST,
-    GPIO_LED_1,
-    GPIO_LED_2,
-    GPIO_LED_3,
-    GPIO_KEY_1,
-    GPIO_KEY_2,
-    GPIO_KEY_3,
-    GPIO_LCD_DCX,
-    GPIO_LCD_PWR,
-    GPIO_LCD_RST,
-    GPIO_PCIE_RST,
-    GPIO_SECURE_CLK,
-    GPIO_SECURE_IO,
-    GPIO_SECURE_RST,
-    GPIO_SIM_DET,
-    GPIO_USB_PCIE_SW,
-    GPIO_WIFI_RST,
-    GPIO_WIFI_WU,
-    GPIO_ZIGBEE_INT,
-    GPIO_ZIGBEE_RST,
-    MAX_GPIO_NUM
+	GPIO_ALS_INT,
+	GPIO_AUDIO_CTL,
+	GPIO_AUDIO_RST,
+	GPIO_AUDIO_WU,
+	GPIO_CAM_PD,
+	GPIO_CAM_RST,
+	GPIO_LED_1,
+	GPIO_LED_2,
+	GPIO_LED_3,
+	GPIO_KEY_1,
+	GPIO_KEY_2,
+	GPIO_KEY_3,
+	GPIO_LCD_DCX,
+	GPIO_LCD_PWR,
+	GPIO_LCD_RST,
+	GPIO_PCIE_RST,
+	GPIO_SECURE_RST,
+	GPIO_SIM_DET,
+	GPIO_USB_PCIE_SW,
+	GPIO_WIFI_RST,
+	GPIO_WIFI_WU,
+	GPIO_ZIGBEE_INT,
+	MAX_GPIO_NUM
 } BOARD_GPIO;
+
+typedef enum {
+	BOARD_HW_UNKNOW = 0,
+	BOARD_HW_VER12,
+	BOARD_HW_VER13,
+	BOARD_HW_END
+} BOARD_HW_VERSION;
 
 extern gpio_dev_t brd_gpio_table[];
 extern i2c_dev_t brd_i2c2_dev;
 extern i2c_dev_t brd_i2c3_dev;
 extern i2c_dev_t brd_i2c4_dev;
 extern uart_dev_t uart_0;
+extern uart_dev_t uart_arduino;
 
 #define KIDS_A10_PRT(fmt, args...)  \
   printf("%s: [%s-->%d]=> "fmt,   \

--- a/board/developerkit/hal/hal_gpio_stm32l4.h
+++ b/board/developerkit/hal/hal_gpio_stm32l4.h
@@ -181,15 +181,12 @@
 #define LCD_PWR                    HAL_GPIO_71     /*PE7*/
 #define LCD_RST                    HAL_GPIO_18     /*PB2*/
 #define PCIE_RST                   HAL_GPIO_45     /*PC13*/
-#define SECURE_CLK                 HAL_GPIO_79     /*PE15*/
-#define SECURE_IO                  HAL_GPIO_0      /*PA0*/
-#define SECURE_RST                 HAL_GPIO_1      /*PA1*/
+#define SECURE_RST                 HAL_GPIO_79     /*PE15*/
 #define SIM_DET                    HAL_GPIO_66     /*PE2*/
 #define USB_PCIE_SW                HAL_GPIO_21     /*PB5*/
 #define WIFI_RST                   HAL_GPIO_16     /*PB0*/
 #define WIFI_WU                    HAL_GPIO_17     /*PB1*/
 #define ZIGBEE_INT                 HAL_GPIO_72     /*PE8*/
-#define ZIGBEE_RST                 HAL_GPIO_55     /*PD7*/
 
 #define GPIOA_SPEED	 GPIO_SPEED_FREQ_VERY_HIGH
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
The UART4 on Developerkit hardware version V13 can not work correctly

**Describe the solution you'd like**
Now the default support V13 correctly initializes the UART. If you want to support V12, you must add parameters "hwver=12" at compile time. E.g
_aos make clean
aos make hwver=12_

**Additional context**
