### PR TITLE
Rel 3.0.0: type fixes for cli and kv

### DIFF
--- a/kernel/cli/cli.c
+++ b/kernel/cli/cli.c
@@ -345,7 +345,7 @@ static int32_t cli_handle_input(char *inbuf)
  * @return none
  *
  */
-static void cli_tab_complete(char *inbuf, unsigned int *bp)
+static void cli_tab_complete(char *inbuf, uint32_t *bp)
 {
     int32_t i, n, m;
 

--- a/kernel/cli/cli_dumpsys.c
+++ b/kernel/cli/cli_dumpsys.c
@@ -346,12 +346,12 @@ uint32_t dumpsys_func(char *pcWriteBuffer, int32_t xWriteBufferLen, int32_t argc
     }
 }
 
-static void task_cmd(char *buf, int len, int argc, char **argv)
+static void task_cmd(char *buf, int32_t len, int32_t argc, char **argv)
 {
     dumpsys_task_func(NULL, 0, 1);
 }
 
-static void dumpsys_cmd(char *buf, int len, int argc, char **argv)
+static void dumpsys_cmd(char *buf, int32_t len, int32_t argc, char **argv)
 {
     dumpsys_func(buf, len, argc, argv);
 }

--- a/kernel/fs/kv/kv_cli.c
+++ b/kernel/fs/kv/kv_cli.c
@@ -17,7 +17,7 @@ void kv_register_cli_command(void) {}
 
 extern kv_item_t *kv_item_traverse(item_func func, uint8_t blk_idx, const char *key);
 
-static int __item_print_cb(kv_item_t *item, const char *key)
+static int32_t __item_print_cb(kv_item_t *item, const char *key)
 {
     kv_size_t off;
 
@@ -50,12 +50,12 @@ static int __item_print_cb(kv_item_t *item, const char *key)
     return KV_LOOP_CONTINUE;
 }
 
-static void handle_kv_cmd(char *pwbuf, int blen, int argc, char **argv)
+static void handle_kv_cmd(char *pwbuf, int32_t blen, int32_t argc, char **argv)
 {
     int i   = 0;
     int num = 0;
     int res = KV_OK;
-    int len = KV_MAX_VAL_LEN;
+    int32_t len = KV_MAX_VAL_LEN;
 
     char *buffer = NULL;
 

--- a/osal/aos/common.c
+++ b/osal/aos/common.c
@@ -31,7 +31,7 @@ void aos_srand(unsigned int seed)
 {
 #if !defined (ENABLE_RNG) && defined (AOS_COMP_KV)
     int           ret        = 0;
-    int           seed_len   = 0;
+    int32_t       seed_len   = 0;
     unsigned int  seed_val   = 0;
     static char  *g_seed_key = "seed_key";
 

--- a/osal/aos/kv.c
+++ b/osal/aos/kv.c
@@ -47,7 +47,7 @@ int aos_kv_set(const char *key, const void *value, int len, int sync)
     return _kv_to_aos_res(kv_item_set(key, value, len));
 }
 
-int aos_kv_get(const char *key, void *buffer, int *buffer_len)
+int aos_kv_get(const char *key, void *buffer, int32_t *buffer_len)
 {
     return _kv_to_aos_res(kv_item_get(key, buffer, buffer_len));
 }
@@ -67,7 +67,7 @@ int aos_kv_secure_set(const char *key, const void *value, int len, int sync)
     return _kv_to_aos_res(kv_item_secure_set(key, value, len));
 }
 
-int aos_kv_secure_get(const char *key, void *buffer, int *buffer_len)
+int aos_kv_secure_get(const char *key, void *buffer, int32_t *buffer_len)
 {
     return _kv_to_aos_res(kv_item_secure_get(key, buffer, buffer_len));
 }

--- a/test/testcase/certificate/certificate_test/aos_test.c
+++ b/test/testcase/certificate/certificate_test/aos_test.c
@@ -843,7 +843,7 @@ CASE(test_kv, aos_2_001)
     char *set_value = "test_kv_value";
     int  set_len = strlen(set_value);
     char get_value[32] = {0};
-    int  get_len = 32;
+    int32_t  get_len = 32;
     int  ret = -1;
 
     ret = aos_kv_set(key, set_value, set_len, 1);
@@ -861,7 +861,7 @@ CASE(test_kv, aos_2_002)
     char *set_value = "test_kv_value";
     int  set_len = strlen(set_value);
     char get_value[32] = {0};
-    int  get_len = 32;
+    int32_t  get_len = 32;
     int  ret = -1;
 
     aos_kv_del(key);
@@ -882,7 +882,7 @@ CASE(test_kv, aos_2_003)
     char set_value[64] = {0};
     int  set_len = 0;
     char get_value[64] = {0};
-    int  get_len = 0;
+    int32_t  get_len = 0;
     int  ret = -1;
     int  i = 0;
 

--- a/test/testcase/kernel/fs/kv/kv_test.c
+++ b/test/testcase/kernel/fs/kv/kv_test.c
@@ -49,7 +49,7 @@ static void test_kv_find(void)
 {
     int ret = 0;
     char buf[10] = {0};
-    int len = sizeof(buf);
+    int32_t len = sizeof(buf);
 
     ret = aos_kv_get(g_key_1,buf,&len);
     YUNIT_ASSERT(0 == ret);
@@ -72,7 +72,7 @@ static void test_kv_del(void)
 {
     int ret = 0;
     char buf[10] = {0};
-    int len = sizeof(buf);
+    int32_t len = sizeof(buf);
 
     ret = aos_kv_del(g_key_1);
     YUNIT_ASSERT(0 == ret);


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Currently, the use of types is sometimes erroneous in kv/cli and related tests. Functions that require int32_t or uint32_t arguments receive int or long (unsigned) int arguments, which triggers warnings and thus errors with standard -Werror flags

**Describe the solution you'd like**
Fix types/ function prototypes where needed as well as in related structs.