### PR TITLE
Aos2.0.0 qcom

### DIFF
--- a/kernel/rhino/core/k_timer.c
+++ b/kernel/rhino/core/k_timer.c
@@ -411,6 +411,7 @@ static void timer_task(void *pa)
                 }
                 else if (err == RHINO_SUCCESS) {
                     g_timer_count = tick_end;
+                    timer_cb_proc();
                     timer_cmd_proc(&cb_msg);
                 }
                 else {

--- a/kernel/uspace/u_timer.c
+++ b/kernel/uspace/u_timer.c
@@ -441,6 +441,7 @@ static void timer_task(void *pa)
                     u_timer_count = tick_end;
                 } else if (err == RHINO_SUCCESS) {
                     u_timer_count = tick_end;
+                    timer_cb_proc();
                     timer_cmd_proc(&cb_msg);
                 } else {
                     err_proc(RHINO_SYS_FATAL_ERR);


### PR DESCRIPTION
sync k_timer.c and utimer.c from rel_3.0.0 to aos2.0.0_qcom branch, fixed bug that may lose timer event if user register too many timer events.