### PR TITLE
问题描述：Issues #1125 Ubuntu 系统默认的 kconfig工具，导致编译失败。

### DIFF
--- a/build/build_rules/aos_kconfig.mk
+++ b/build/build_rules/aos_kconfig.mk
@@ -24,24 +24,8 @@ ifneq (,$(wildcard $(KCONFIG_DIR)COPYING))
 KCONFIG_TOOLPATH := $(KCONFIG_DIR)
 endif
 
-ifeq (,$(KCONFIG_TOOLPATH))
-ifeq ($(HOST_OS),Win32)
-SYSTEM_KCONFIG_TOOLPATH = $(shell where kconfig-mconf.exe)
-else
-SYSTEM_KCONFIG_TOOLPATH = $(shell which kconfig-mconf)
-endif
-
-ifeq (,$(findstring kconfig-mconf,$(SYSTEM_KCONFIG_TOOLPATH)))
 KCONFIG_TOOLPATH := $(KCONFIG_DIR)
 DOWNLOAD_KCONFIG = yes
-endif
-
-# Fix for which output: "no kconfig-mconf in ..."
-ifneq (,$(findstring no kconfig-mconf in,$(SYSTEM_KCONFIG_TOOLPATH)))
-KCONFIG_TOOLPATH := $(KCONFIG_DIR)
-DOWNLOAD_KCONFIG = yes
-endif
-endif
 
 KCONFIG_MCONF := $(KCONFIG_TOOLPATH)kconfig-mconf
 KCONFIG_CONF := $(KCONFIG_TOOLPATH)kconfig-conf


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Issues #1125 Ubuntu 系统默认的 kconfig工具，导致编译失败。

**Describe the solution you'd like**
Ubuntu 16、CentOS 7系统， aos_kconfig.mk 使用系统默认的 kconfig工具，导致生成的 .config 选项带有 CONFIG_ 前缀，编译失败。

https://user-images.githubusercontent.com/19748676/75410637-7fd65080-5957-11ea-824a-87567874f8d2.png

**Additional context**
修改方法：build/build_rules/aos_kconfig.mk 强制下载、使用 AliOS 提供的 kconfig 工具。
验证结果：强制使用AliOS提供的 kconfig 工具，可以生成不带 CONFIG_ 前缀的 .config ，可以正常编译。

https://user-images.githubusercontent.com/19748676/75410663-94b2e400-5957-11ea-8ad4-5f416903cae9.png
https://user-images.githubusercontent.com/19748676/75410708-b90ec080-5957-11ea-8423-327866a24377.png
https://user-images.githubusercontent.com/19748676/75410726-c62baf80-5957-11ea-8153-20b0e7f3361e.png
