### PR TITLE
问题描述：pthread 相关头文件和编译链头文件冲突，导致 stm32f429zi-nucleo 开启 posix 选项之后编译不通过。

### DIFF
--- a/board/stm32f429zi-nucleo/aos.mk
+++ b/board/stm32f429zi-nucleo/aos.mk
@@ -58,7 +58,7 @@ GLOBAL_INCLUDES += .    \
                    aos/ \
                    Inc/
 
-GLOBAL_CFLAGS  += -DSTM32F429xx -DCENTRALIZE_MAPPING
+GLOBAL_CFLAGS  += -DSTM32F429xx -DCENTRALIZE_MAPPING -D_POSIX_C_SOURCE=0
 
 ifeq ($(COMPILER),armcc)
 GLOBAL_LDFLAGS += -L --scatter=board/stm32f429zi-nucleo/STM32F429ZITx.sct


### PR DESCRIPTION
问题根因：gcc-arm-none-eabi-linux 工具链默认开启了 posix 选项，AliOS 新增的 pthread.h 重复定义了 pthread_t，导致编译失败。
修改方法：stm32f429zi-nucleo 的编译选项增加 -D_POSIX_C_SOURCE=0，忽略工具链的 posix 相关特性，避免冲突。
验证结果：修改之后，开启 posix 选项，能够编译通过。
注意：其他板卡也存在该问题，可能全部需要合入该选项。

修改前：
![image](https://user-images.githubusercontent.com/19748676/75582249-1dd83100-5aa6-11ea-9ba9-26d0a0e1701a.png)

修改后：
![image](https://user-images.githubusercontent.com/19748676/75582286-36484b80-5aa6-11ea-9b4c-6bc7e1f3a7bc.png)
