### PR TITLE
问题描述：kv 系统的主线程低概率丢失唤醒事件，导致系统死机

### DIFF
--- a/kernel/fs/kv/kv_types.h
+++ b/kernel/fs/kv/kv_types.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2015-2017 Alibaba Group Holding Limited
  */
 
@@ -181,10 +181,8 @@ typedef struct _block_info_t {
 typedef struct _kv_mgr_t {
     uint8_t       inited;
     uint8_t       gc_trigger;
-    uint8_t       gc_waiter;
     uint8_t       clean_blk_nums;
     kv_size_t     write_pos;
-    void         *gc_sem;
     void         *lock;
     block_info_t  block_info[KV_BLOCK_NUMS];
 } kv_mgr_t;


### PR DESCRIPTION
问题根因：kv 系统的主线程操作之前需要判断GC线程是否正在运行，如果GC正在执行，则需要等待信号量。
GC执行完毕之后通过信号量唤醒正在等待的主线程。
由于主线程判断 gc_trigger 、递增 gc_waiter、kv_sem_wait(gc_sem)三个操作没有锁保护，如果在第一、二步之间被GC抢占，则会导致主线程丢失唤醒信号，系统死机。
修改方法：主线程、GC线程通过 g_kv_mgr.lock 进行互斥即可，不需要 gc_sem、gc_waiter 参与。
验证结果：修改之后，系统不再死机。

**Is your feature request related to a problem? Please describe.**


**Describe the solution you'd like**


**Additional context**
