### PR TITLE
IssueID:1500:add check for the inet_aton

### DIFF
--- a/components/amp_adapter/platform/aos/network/aos_udp.c
+++ b/components/amp_adapter/platform/aos/network/aos_udp.c
@@ -109,7 +109,8 @@ int aos_udp_create(char *host, unsigned short port)
     for (ainfo = res; ainfo != NULL; ainfo = ainfo->ai_next) {
         if (AF_INET == ainfo->ai_family) {
             sa = (struct sockaddr_in *)ainfo->ai_addr;
-            inet_ntop(AF_INET, &sa->sin_addr, addr, NETWORK_ADDR_LEN);
+            if (inet_ntop(AF_INET, &sa->sin_addr, addr, NETWORK_ADDR_LEN) == NULL)
+                return -1;
 
             socket_id = socket(ainfo->ai_family, ainfo->ai_socktype, ainfo->ai_protocol);
             if (socket_id < 0) {
@@ -229,8 +230,9 @@ int aos_udp_recvfrom(int sockfd, aos_networkAddr *p_remote,
     }
     if (from.sa_family == AF_INET) {
         struct sockaddr_in *sin = (struct sockaddr_in *)&from;
-        inet_ntop(AF_INET, &sin->sin_addr, (char *)p_remote->addr,
-                  NETWORK_ADDR_LEN);
+        if (inet_ntop(AF_INET, &sin->sin_addr, (char *)p_remote->addr,
+                         NETWORK_ADDR_LEN) == NULL)
+            return -1;
         p_remote->port = ntohs(sin->sin_port);
     }
     return count;


### PR DESCRIPTION
[Detail]
Issue description:
In other places, the return value of inet_aton is always checked.  So
the whitescan ask for the same check here.

Solution:
Add check of the return value.

[Verified Cases]
Build Pass: eduk1_demo
Test Pass: eduk1_demo

Change-Id: I7515cb248d2d75e2fd5080766d310d7496506e5d
Signed-off-by: yilu.myl <yilu.myl@alibaba-inc.com>