### PR TITLE
IssueID:1503:fix wrong sizeof usage

### DIFF
--- a/components/amp_adapter/platform/aos/peripheral/aos_hal_gpio.c
+++ b/components/amp_adapter/platform/aos/peripheral/aos_hal_gpio.c
@@ -33,7 +33,7 @@ int32_t aos_hal_gpio_init(gpio_dev_t *gpio)
 
     aos_gpioc_ref_t *gpioc;
     gpioc = aos_malloc(sizeof(aos_gpioc_ref_t));
-    memset(gpioc, 0, sizeof(gpioc));
+    memset(gpioc, 0, sizeof(aos_gpioc_ref_t));
     int32_t pin_index = gpio->port;
     int32_t gpioc_index = 0;
 


### PR DESCRIPTION
[Detail]
Issue description:
When clean the buffer, use a sizeof(pointer) is not right.

Solution:
Change the pointer to its type to make sure the size if correct.

[Verified Cases]
Build Pass: eduk1_demo
Test Pass: eduk1_demo

Change-Id: Ifb0a05e3fb51a9e51d99fb8a69dd867b892ca5f2
Signed-off-by: yilu.myl <yilu.myl@alibaba-inc.com>