### PR TITLE
IssueID:1505:Fix bug found by whitScan

### DIFF
--- a/components/drivers/peripheral/i2c/src/i2c_core.c
+++ b/components/drivers/peripheral/i2c/src/i2c_core.c
@@ -108,7 +108,7 @@ i2c_dev_handle_t aos_i2c_open (uint32_t id, i2c_slave_config_t *config) {
     }
 
     if (!config) {
-        ddkc_err("config is NULL, invalid\r\n", config);
+        ddkc_err("config is NULL, invalid\r\n");
         return NULL;
     }
 


### PR DESCRIPTION
[Detail]
Issue description:
The number of arguments to printf does not match the format string.

Solution:
Remove argument "config".

[Verified Cases]
Build Pass: <helloworld_demo@haaseduk1>
Test Pass: <helloworld_demo@haaseduk1>
