### PR TITLE
IssueID:1515:add value return for all branches

### DIFF
--- a/components/amp_adapter/platform/aos/peripheral/aos_hal_wdg.c
+++ b/components/amp_adapter/platform/aos/peripheral/aos_hal_wdg.c
@@ -16,7 +16,7 @@
 int32_t aos_hal_wdg_init(wdg_dev_t *wdg)
 {
 #if (defined(BOARD_HAAS100) || defined(BOARD_HAASEDUK1))
-    hal_wdg_init(wdg);
+    return hal_wdg_init(wdg);
 #else
 #ifndef AOS_BOARD_HAAS700
     uint32_t flags = 0;
@@ -88,7 +88,7 @@ void aos_hal_wdg_reload(wdg_dev_t *wdg)
 int32_t aos_hal_wdg_finalize(wdg_dev_t *wdg)
 {
 #if (defined(BOARD_HAAS100) || defined(BOARD_HAASEDUK1))
-    hal_wdg_finalize(wdg);
+    return hal_wdg_finalize(wdg);
 #else
 #ifndef AOS_BOARD_HAAS700
     int32_t ret = 0;


### PR DESCRIPTION
[Detail]
Issue description:
When board is 100 or k1, there is no return value is the two functions.

Solution:
Add the return value.

[Verified Cases]
Build Pass: eduk1_demo
Test Pass: eduk1_demo

Change-Id: Ice748394d9bb413dda7df2f4a77930a02fa2f932
Signed-off-by: yilu.myl <yilu.myl@alibaba-inc.com>
