### PR TITLE
mbedtls: fix whitescan bug in library/cipher.c

### DIFF
--- a/components/mbedtls/library/cipher.c
+++ b/components/mbedtls/library/cipher.c
@@ -459,11 +459,6 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
          */
         if( 0 != ilen )
         {
-            if( 0 == block_size )
-            {
-                return( MBEDTLS_ERR_CIPHER_INVALID_CONTEXT );
-            }
-
             /* Encryption: only cache partial blocks
              * Decryption w/ padding: always keep at least one whole block
              * Decryption w/o padding: only cache partial blocks


### PR DESCRIPTION
[Detail]
Remove dead code in library/cipher.c
CWE561: Code can never be reached because of a logical contradiction

[Verified Cases]
Build Pass: <py_engine_demo>
Test Pass:  <py_engine_demo>

Signed-off-by: Jinliang Li <ljl150821@alibaba-inc.com>