### PR TITLE
posix: fix whitescan bugs

### DIFF
--- a/components/posix/src/pthread.c
+++ b/components/posix/src/pthread.c
@@ -157,7 +157,9 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
             }
         }
     } else {
-        pthread_attr_init(&(ptcb->attr));
+        ret = pthread_attr_init(&(ptcb->attr));
+        if (ret != 0)
+            goto out3;
     }
 
     /* Init joinable semaphore. */

--- a/components/posix/src/temp.c
+++ b/components/posix/src/temp.c
@@ -3,37 +3,43 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <pthread.h>
+#include <aos/kernel.h>
 
 #define TEMP_PATH_MAX 64
-#define TEMP_FILE_NAME_MAGIC "/tmp/du2s5sz3"
+#define TEMP_FILE_PREFIX "/data/tmp"
 
 pthread_mutex_t g_tmpnam_lock = PTHREAD_MUTEX_INITIALIZER;
 
 char *tmpnam(char *s)
 {
     int ret;
+    unsigned int seed;
     static int temp_name_series = 0;
-    char *temp_name_prefix = TEMP_FILE_NAME_MAGIC;
-    char  temp_name_series_buf[8] = {0};
+    char *temp_name_prefix = TEMP_FILE_PREFIX;
+    char  temp_name_series_buf[64] = {0};
 
     if (temp_name_series >= TMP_MAX) {
         return NULL;
     }
 
+    seed = aos_now_ms() + random();
+    srandom(seed);
     ret = pthread_mutex_lock(&g_tmpnam_lock);
     if (ret != 0) {
         return NULL;
     }
-
-    strncpy(s, temp_name_prefix, TEMP_PATH_MAX);
-    snprintf(temp_name_series_buf, sizeof(temp_name_series_buf) - 1, "_%d", temp_name_series);
-    strncat(s, temp_name_series_buf, TEMP_PATH_MAX - strlen(s) - 1);
-
     temp_name_series++;
-
+    snprintf(temp_name_series_buf, sizeof(temp_name_series_buf) - 1,
+        "_%d%d%d", temp_name_series, random(), random());
     pthread_mutex_unlock(&g_tmpnam_lock);
+
+    /* Temp file should be unpredictable names for security consideration. */
+    strncpy(s, temp_name_prefix, TEMP_PATH_MAX);
+    strncat(s, temp_name_series_buf, TEMP_PATH_MAX - strlen(s) - 1);
 
     return s;
 }


### PR DESCRIPTION
[Detail]
temp.c: CWE377: Using an insecure temporary file creation function
pthread.c CWE252: Value returned from a function is not checked for
errors before being used

[Verified Cases]
Build Pass: <py_engine_demo>
Test Pass:  <py_engine_demo>

Signed-off-by: Jinliang Li <ljl150821@alibaba-inc.com>