### PR TITLE
cli: fix whitescan bugs in cli/iobox

### DIFF
--- a/components/cli/src/iobox/cd.c
+++ b/components/cli/src/iobox/cd.c
@@ -76,7 +76,7 @@ static int cd_main(int argc, char **argv)
         }
 
         // parse heading ".."
-        while (target && strncmp(target, "..", strlen("..")) == 0) {
+        while (strncmp(target, "..", strlen("..")) == 0) {
             if (up_one_level(absolute) != 0) {
                 aos_cli_printf("up to parent dir failed. %s may " \
                            "not be a valid path!", target);
@@ -88,9 +88,8 @@ static int cd_main(int argc, char **argv)
                 target++;
         }
 
-        if (target)
-            strncpy(absolute + strlen(absolute), target, \
-                            sizeof(absolute) - strlen(absolute));
+        strncpy(absolute + strlen(absolute), target,
+                sizeof(absolute) - strlen(absolute));
     } else {
         strncpy(absolute, target, sizeof(absolute));
     }

--- a/components/cli/src/iobox/cp.c
+++ b/components/cli/src/iobox/cp.c
@@ -123,7 +123,8 @@ static int cp_dir_to_dir(const char *from, const char *to)
     pdir = opendir(from);
     if (!pdir) {
         aos_cli_printf("opendir %s failed\n", from);
-        return -1;
+        ret = -1;
+        goto free;
     }
 
     while ((entry = readdir(pdir))) {

--- a/components/cli/src/iobox/ls.c
+++ b/components/cli/src/iobox/ls.c
@@ -158,7 +158,7 @@ static int ls_do(int argc, char **argv, int flags)
             }
 
             // parse heading ".."
-            while (dir && (strncmp(dir, "..", strlen(".."))) == 0) {
+            while (strncmp(dir, "..", strlen("..")) == 0) {
                 if (up_one_level(cur) != 0) {
                     aos_cli_printf("up to parent dir failed. %s may " \
                                "not be a valid path!", dir);
@@ -173,13 +173,12 @@ static int ls_do(int argc, char **argv, int flags)
             }
 
             // deal with '.', './', './dir/file' cases
-            if (dir && dir[0] == '.') {
+            if (dir[0] == '.') {
                 while (*(++dir) == '/')
                     ;
             }
 
-            if (dir)
-                snprintf(cur + curlen, sizeof(cur) - curlen, "/%s", dir);
+            snprintf(cur + curlen, sizeof(cur) - curlen, "/%s", dir);
             dir = cur;
         }
 

--- a/components/cli/src/iobox/mv.c
+++ b/components/cli/src/iobox/mv.c
@@ -62,15 +62,17 @@ static int mv_main(int argc, char **argv)
     ret = rename(from, to);
     if (ret < 0 && errno != EXDEV) {
         aos_cli_printf("rename %s to %s failed - %s\n", from, to, strerror(errno));
-        return -1;
+        ret = -1;
+        goto free;
     } else if (ret == 0) {
-        return 0;
+        goto free;
     }
 
     fd_from = open(from, O_RDONLY);
     if (fd_from < 0) {
         aos_cli_printf("open %s failed - %s\n", from, strerror(errno));
-        return -1;
+        ret = -1;
+        goto free;
     }
 
     fd_to = open(to, O_WRONLY | O_CREAT | O_TRUNC);
@@ -103,6 +105,7 @@ close_to:
     close(fd_to);
 close_from:
     close(fd_from);
+free:
     if (isdir)
         free(to);
     return ret;


### PR DESCRIPTION
[Detail]
fix whitescan bugs in cli/iobox
CWE476: All paths that lead to this null pointer comparison already
dereference the pointer earlier
CWE404: Leak of memory or pointers to system resources

[Verified Cases]
Build Pass: <py_engine_demo>
Test Pass:  <py_engine_demo>

Signed-off-by: Jinliang Li <ljl150821@alibaba-inc.com>