### PR TITLE
IssueID:1500:add check for the inet_aton

### DIFF
--- a/components/amp_adapter/platform/aos/network/aos_udp.c
+++ b/components/amp_adapter/platform/aos/network/aos_udp.c
@@ -166,7 +166,11 @@ int aos_udp_create_without_connect(const char *host, unsigned short port)
     memset(&local_addr, 0x00, sizeof(local_addr));
     local_addr.sin_family = AF_INET;
     if (NULL != host) {
-        inet_aton(host, &local_addr.sin_addr);
+        if (inet_aton(host, &local_addr.sin_addr) == 0) {
+            close(socket_id);
+            platform_err("inet_aton failed\r\n");
+            return (intptr_t)-1;
+        }
     } else {
         local_addr.sin_addr.s_addr = htonl(INADDR_ANY);
     }


### PR DESCRIPTION
[Detail]
Issue description:
In other places, the return value of inet_aton is always checked.  So
the whitescan ask for the same check here.

Solution:
Add check of the return value.

[Verified Cases]
Build Pass: eduk1_demo
Test Pass: eduk1_demo

Change-Id: I3614c162c5ed7a1222c4b1d8ec7f4e1b1bc612c3
Signed-off-by: yilu.myl <yilu.myl@alibaba-inc.com>
