### PR TITLE
IssueID:1542:return value when function finish

### DIFF
--- a/components/amp_adapter/platform/aos/peripheral/aos_hal_rtc.c
+++ b/components/amp_adapter/platform/aos/peripheral/aos_hal_rtc.c
@@ -8,19 +8,23 @@
 int32_t aos_hal_rtc_init(rtc_dev_t *rtc)
 {
     //return hal_rtc_init(rtc);
+    return 0;
 }
 
 int32_t aos_hal_rtc_get_time(rtc_dev_t *rtc, rtc_time_t *time)
 {
     //return hal_rtc_get_time(rtc, time);
+    return 0;
 }
 
 int32_t aos_hal_rtc_set_time(rtc_dev_t *rtc, const rtc_time_t *time)
 {
     //return hal_rtc_set_time(rtc, time);
+    return 0;
 }
 
 int32_t aos_hal_rtc_finalize(rtc_dev_t *rtc)
 {
     //return hal_rtc_finalize(rtc);
+    return 0;
 }


### PR DESCRIPTION
[Detail]
Issue description:
In components/amp_adapter/platform/aos/peripheral/aos_hal_rtc.c, the
functions all has no return value.

Solution:
Add return value in them.

[Verified Cases]
Build Pass: eduk1_demo
Test Pass: eduk1_dem

Signed-off-by: yilu.myl <yilu.myl@alibaba-inc.com>
