### PR TITLE
IssueID:1545:return value when function finish

### DIFF
--- a/components/amp_adapter/platform/aos/peripheral/aos_hal_can.c
+++ b/components/amp_adapter/platform/aos/peripheral/aos_hal_can.c
@@ -49,7 +49,6 @@ void can1_receive_callback(void)
     }
 
     can_received = 1;
-
 }
 
 void can2_receive_callback(void)
@@ -63,7 +62,6 @@ void can2_receive_callback(void)
     }
 
     can_received = 1;
-
 }
 
 int32_t aos_hal_can_recv(can_dev_t *can, can_frameheader_t *rx_header, void *data, const uint32_t timeout)
@@ -87,6 +85,7 @@ int32_t aos_hal_can_recv(can_dev_t *can, can_frameheader_t *rx_header, void *dat
             return 0;
         }
     }
+    return 0;
 }
 
 int32_t aos_hal_can_finalize(can_dev_t *can)


### PR DESCRIPTION
[Detail]
Issue description:
In components/amp_adapter/platform/aos/peripheral/aos_hal_can.c, one
branch of the function aos_hal_can_recv  has no return value.

Solution:
add return there.

[Verified Cases]
Build Pass: eduk1_demo
Test Pass: eduk1_demo

Signed-off-by: yilu.myl <yilu.myl@alibaba-inc.com>
