### PR TITLE
init: fix build error when trace is enabled

### DIFF
--- a/components/init/aos_init.c
+++ b/components/init/aos_init.c
@@ -41,6 +41,8 @@
 #include "und/und.h"
 #endif
 
+#include "k_api.h"
+
 #ifdef IPERF_ENABLED
 extern int iperf_cli_register(void);
 #endif


### PR DESCRIPTION
[Detail]
Fix the linking error: "undefined reference to TRACE_INIT" when trace is
enabled.

[Verified Cases]
Build Pass: <py_engine_demo>
Test Pass:  <py_engine_demo>