### PR TITLE
change the function return as void, fixed #1599

### DIFF
--- a/components/amp_adapter/platform/aos/aos_system.c
+++ b/components/amp_adapter/platform/aos/aos_system.c
@@ -49,7 +49,7 @@ void aos_printf(const char *fmt, ...)
     fflush(stdout);
 }
 
-int aos_putchar(const char c)
+void aos_putchar(const char c)
 {
     aos_printf("%c", c);
 }


### PR DESCRIPTION
Change the function as void return since it is same in linux adapter
