### PR TITLE
add return value for every condition, fixed #1601

### DIFF
--- a/hardware/chip/haas1000/hal/audio.c
+++ b/hardware/chip/haas1000/hal/audio.c
@@ -222,6 +222,7 @@ static pcm_stream_handler_t codec_pcm_stream_open(int mode, int sampleRate, int 
              playback_stream_hdl, PCM_STREAM_OUT, sampleRate, channels, format);
         return playback_stream_hdl;
     }
+    return NULL;
 }
 
 static int codec_pcm_stream_start(pcm_stream_handler_t hdl)


### PR DESCRIPTION
[Detail]
Issue description:
Function that returns non-void is missing a return value
Arriving at the end of a function without returning a value.

Solution:
Add return value at the end of function.

[Verified Cases]
Build Pass: eduk1_demo
Test Pass: eduk1_demo

Signed-off-by: Yilu Mao <yilu.myl@alibaba-inc.com>
