### PR TITLE
Change the type of address into unsigned int to print, fixes #1604

### DIFF
--- a/hardware/chip/haas1000/hal/audio.c
+++ b/hardware/chip/haas1000/hal/audio.c
@@ -214,12 +214,12 @@ static pcm_stream_handler_t codec_pcm_stream_open(int mode, int sampleRate, int 
         }
         capture_stream_hdl = data_dump_open(aud_record_subscribe, _kfifo_len / 1024, sampleRate, 0);
         LOGD(LOG_TAG, "%s:%d: capture_stream_hdl 0x%x, mode %d, sampleRate %d, channels %d, format %d \r\n", __func__, __LINE__,
-             capture_stream_hdl, PCM_STREAM_OUT, sampleRate, channels, format);
+             (unsigned int)capture_stream_hdl, PCM_STREAM_OUT, sampleRate, channels, format);
         return capture_stream_hdl;
     } else if (mode == PCM_STREAM_OUT) {
         playback_stream_hdl = (pcm_stream_handler_t)alsa_open(ALSA_MODE_OUT, sampleRate, channels, format);
         LOGD(LOG_TAG, "%s:%d: playback_stream_hdl 0x%x, mode %d, sampleRate %d, channels %d, format %d \r\n", __func__, __LINE__,
-             playback_stream_hdl, PCM_STREAM_OUT, sampleRate, channels, format);
+             (unsigned int)playback_stream_hdl, PCM_STREAM_OUT, sampleRate, channels, format);
         return playback_stream_hdl;
     }
 }


### PR DESCRIPTION
[Detail]
Issue description:
An argument with the wrong type was passed to a print format specifier.
Argument "playback_stream_hdl" to format specifier "%x" was expected to have type "unsigned int" but has type "void *".

Solution:
add the type declaration for it.

[Verified Cases]
Build Pass: eduk1_demo
Test Pass: eduk1_demo
