### PR TITLE
Fix board disattach spelling error for modbus

### DIFF
--- a/components/py_engine/modules/modbus/modbus.c
+++ b/components/py_engine/modules/modbus/modbus.c
@@ -41,7 +41,7 @@ STATIC mp_int_t parser_from_board_configuration_file(const char *id, modbus_dev_
 
 out:
     if (0 != ret) {
-        py_board_disattach_item(MODULE_ADC, &modbus_handle);
+        py_board_disattach_item(MODULE_MODBUS, &modbus_handle);
     }
 
     return ret;


### PR DESCRIPTION
Change-Id: I8ffddeb43bfbc0903e046b2854a305879c5ad5f3