### PR TITLE
Change the expression, fixes #1634

### DIFF
--- a/hardware/chip/haas1000/aos/ota_port.c
+++ b/hardware/chip/haas1000/aos/ota_port.c
@@ -441,7 +441,7 @@ int ota_get_boot_type()
 
 int ota_set_user_bootinfo(void *param)
 {
-    (void *)param;
+    (void)param;
     return ota_upgrade_link();
 }
 


### PR DESCRIPTION
The type of param is (void*), so the expression, (void *)param, is
meaningless.  Change it to (void)param.
