### PR TITLE
pwm: convert pwm duty type to float, fix #1652

### DIFF
--- a/components/amp_adapter/platform/aos/peripheral/aos_hal_pwm.c
+++ b/components/amp_adapter/platform/aos/peripheral/aos_hal_pwm.c
@@ -135,8 +135,7 @@ int32_t aos_hal_pwm_para_chg(pwm_dev_t *pwm, pwm_config_t para)
         printf ("set freq to %d on pwm%d failed, ret:%d\r\n", para.freq, pwm->port, ret);
     }
 
-    int duty = 0;
-    duty = para.duty_cycle / 100;
+    float duty = para.duty_cycle / 100.0;
     ret = ioctl(*p_fd, IOC_PWM_DUTY_CYCLE, (unsigned long)&duty);
     if (ret) {
         printf("set duty cycle to %d on pwm%d failed, ret:%d\r\n", duty, pwm->port, ret);


### PR DESCRIPTION
[Detail]
pwm duty type should be float type

[Verified Cases]
Build Pass: <py_engine_demo>
Test Pass:  <py_engine_demo>