### PR TITLE
Change the return value type, fixed #1736

### DIFF
--- a/hardware/chip/haas1000/aos/ota_port.c
+++ b/hardware/chip/haas1000/aos/ota_port.c
@@ -243,7 +243,7 @@ void ota_set_zoneAB_bootinfo_to_default(void)
 
 enum bootinfo_zone ota_get_valid_bootinfo_zone(void)
 {
-    enum bootinfo_zone ret = OTA_BOOTINFO_ZONEA;
+    int ret = OTA_BOOTINFO_ZONEA;
 
     //get boot info to choose linkA or linkB.
     ret = ota_check_bootinfo(OTA_BOOTINFO_ZONEA);


### PR DESCRIPTION
An enum-typed expression is used in a Boolean conditional context. The
enum type does not appear to have a distinguished false (zero) value.

Change the type as int to fix such issue.
