### PR TITLE
posix: support timezone and daylight in newlib libc

### DIFF
--- a/components/libc_stub/newlib_stub.c
+++ b/components/libc_stub/newlib_stub.c
@@ -335,25 +335,6 @@ int _gettimeofday_r(struct _reent *ptr, struct timeval *tv, void *__tzp)
     return 0;
 }
 
-long timezone = 0; /* global variable */
-
-struct tm* localtime_r(const time_t* t, struct tm* r)
-{
-    time_t time_tmp;
-    time_tmp = *t + timezone;
-    return gmtime_r(&time_tmp, r);
-}
-
-struct tm* localtime(const time_t* t)
-{
-    struct tm* timeinfo;
-    static struct tm tm_tmp;
-
-    timeinfo = localtime_r(t, &tm_tmp);
-
-    return timeinfo;
-}
-
 void *_malloc_r(struct _reent *ptr, size_t size)
 {
     void *mem;

--- a/components/posix/src/enviro.c
+++ b/components/posix/src/enviro.c
@@ -7,6 +7,10 @@
 #include <enviro.h>
 #include <aos/kernel.h>
 
+/* Define POSIX_ENV as 1 to enable env apis here when there is no env apis in libc.
+ * Note: Newlib libc already implements env apis, tzset depends on them.
+ */
+#if (POSIX_ENV > 0)
 pthread_mutex_t g_enviro_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_environ_t *g_penviron = NULL;
 
@@ -324,6 +328,7 @@ int clearenv(void)
 
     return 0;
 }
+#endif /*(POSIX_ENV > 0) */
 
 int uname(struct utsname *name)
 {


### PR DESCRIPTION
Use localtime/localtime_r and env apis in newlib libc, and remove
duplicate implementation in posix and newlib_stub_uspace.

Signed-off-by: Jinliang Li <ljl150821@alibaba-inc.com>