### PR TITLE
IssueID:1815:decrease mp_stack, queue_handler, gui , ota, and linksdk…

### DIFF
--- a/components/py_engine/adapter/esp32/main.c
+++ b/components/py_engine/adapter/esp32/main.c
@@ -87,7 +87,7 @@
 
 // MicroPython runs as a task under FreeRTOS
 #define MP_TASK_PRIORITY   (ESP_TASK_PRIO_MIN + 1)
-#define MP_TASK_STACK_SIZE (16 * 1024)
+#define MP_TASK_STACK_SIZE (8 * 1024)
 
 // Set the margin for detecting stack overflow, depending on the CPU architecture.
 #if CONFIG_IDF_TARGET_ESP32C3
@@ -329,7 +329,7 @@ void app_main(void)
     littlefs_register();
 
     TaskHandle_t mp_queue_task_handle;
-    ret = xTaskCreatePinnedToCore(queue_handler_task, "queue_handler", 1024 * 8 / sizeof(StackType_t), NULL,
+    ret = xTaskCreatePinnedToCore(queue_handler_task, "queue_handler", 1024 * 3 / sizeof(StackType_t), NULL,
                                   ESP_TASK_PRIO_MIN + 3, &mp_queue_task_handle, MP_TASK_COREID);
     if (ret != pdPASS) {
         printf("queue_handler_task creat failed!\r\n");

--- a/components/py_engine/modules/aliyunIoT/module_aiot_mqtt.c
+++ b/components/py_engine/modules/aliyunIoT/module_aiot_mqtt.c
@@ -328,7 +328,7 @@ int32_t pyamp_aiot_mqtt_client_start(void **handle, int keepaliveSec, iot_mqtt_u
 
     aos_task_t mqtt_process_task;
 
-    if (aos_task_new_ext(&mqtt_process_task, "mqtt_process", pyamp_aiot_app_mqtt_process_thread, mqtt_handle, 1024 * 4,
+    if (aos_task_new_ext(&mqtt_process_task, "mqtt_process", pyamp_aiot_app_mqtt_process_thread, mqtt_handle, (1024 * 2 + 512),
                          AOS_DEFAULT_APP_PRI) != 0) {
         amp_debug(MOD_STR, "management mqtt process task create failed!\r\n");
         aiot_mqtt_deinit(&mqtt_handle);

--- a/components/py_engine/modules/display/esp32/moddisplay.c
+++ b/components/py_engine/modules/display/esp32/moddisplay.c
@@ -110,7 +110,7 @@ int mp_thread_create_c(TaskFunction_t pxTaskCode, const char *const pcName, cons
 
 void start_display()
 {
-    mp_thread_create_c(guiTask, "gui", 4 * 1024, NULL, ESP_TASK_PRIO_MIN + 1, NULL, 0);
+    mp_thread_create_c(guiTask, "gui", 2 * 1024, NULL, ESP_TASK_PRIO_MIN + 1, NULL, 0);
 }
 
 void driver_init()

--- a/components/py_engine/modules/ota/modota.c
+++ b/components/py_engine/modules/ota/modota.c
@@ -162,7 +162,7 @@ static void ota_verify_handler(void *pdata)
             strlen(ota_package_info->hash));
     res = ota_verify_fsfile(&ota_param, ota_package_info->store_path);
     if (res < 0) {
-        amp_error(MOD_STR, "amp jsota verified failed!");
+        amp_error(MOD_STR, "ota verified failed!");
     }
     ota_package_info->res = res;
     py_task_schedule_call(ota_verify_notify, ota_package_info);
@@ -224,7 +224,7 @@ static mp_obj_t py_ota_verify(mp_obj_t data)
             sizeof(ota_package_info->store_path));
 
     res = aos_task_new_ext(&ota_verify_task, "amp ota verify task",
-                           ota_verify_handler, ota_package_info, 1024 * 10,
+                           ota_verify_handler, ota_package_info, 1024 * 5,
                            AOS_DEFAULT_APP_PRI);
     if (res != 0) {
         amp_warn(MOD_STR, "iot create task failed");
@@ -297,7 +297,7 @@ static mp_obj_t ota_download(mp_obj_t data)
             sizeof(ota_package_info->store_path));
 
     res = aos_task_new_ext(&ota_download_task, "amp ota download task",
-                           ota_download_handler, ota_package_info, 1024 * 10,
+                           ota_download_handler, ota_package_info, 1024 * 5,
                            AOS_DEFAULT_APP_PRI);
     if (res != 0) {
         amp_warn(MOD_STR, "iot create task failed");


### PR DESCRIPTION
… thread stack size and optimise memory layout statics.

[Detail]
on m5stackcore2, with lvgl, linksdk, online update all on,mp_stack stack remains still 3636
when set from 16KB to 8KB.
on m5stackcore2, with lvgl, linksdk, online update all on,queue_handler stack remains still 1776
when set from 8KB to 3KB.
on m5stackcore2, user logic is placed on mp_task, so mqtt_rec's stack remains 1676 should be enough.
mqtt_process only process repub, hearbeat and some event, on m5stackcore2, mqtt_process's stack
remains 1504 should be enough.
for arm and xtensa, stack should be enough based on current sitution
but for esp32_c3 riscv, due to c11 tls, every stack will have another 1KB space, needs to remove it.

[Verified Cases]
Build Pass: <py_engine_esp32_demo>
Test Pass: <py_engine_esp32_demo>