### PR TITLE
IssueID:1794:close bt on nodemcu32s on default.

### DIFF
--- a/components/py_engine/adapter/esp32/fs/boot.py
+++ b/components/py_engine/adapter/esp32/fs/boot.py
@@ -1,12 +1,13 @@
 import kv
 import time
 import _thread
-
+import uos
 def _on_get_url(url):
     kv.set('_amp_pyapp_url',url)
     execfile('/lib/appOta.py')
 
 def _connect_wifi():
+    time.sleep(5)
     ssid = kv.get('_amp_wifi_ssid')
     passwd = kv.get('_amp_wifi_passwd')
     if isinstance(ssid,str) and isinstance(passwd,str):
@@ -14,14 +15,15 @@ def _connect_wifi():
         sta_if = network.WLAN(network.STA_IF)
         if not sta_if.isconnected():
             sta_if.active(True)
-            sta_if.scan()
             sta_if.connect(ssid,passwd)
+
+bt_disabled = kv.get('disable_bt')
+if bt_disabled != "no":
+    uos.plussys_mm()
 
 channel = kv.get('app_upgrade_channel')
 if channel == "disable":
     pass
-elif channel == "bt":
-    execfile('/lib/oneMinuteOnCloud.py')
 else:
     import online_upgrade
     online_upgrade.on(_on_get_url)


### PR DESCRIPTION
[Detail]
to open bt on nodemcu32s, need to do things as below.
import kv
kv.set("disable_bt", "no")
然后重启设备

[Verified Cases]
Build Pass: <none>
Test Pass: <none>