### PR TITLE
IssueID:1832:Fix the return value of hal_uart_recv_II

### DIFF
--- a/hardware/chip/haas1000/hal/uart.c
+++ b/hardware/chip/haas1000/hal/uart.c
@@ -564,11 +564,6 @@ int32_t hal_uart_recv_II(uart_dev_t *uart, void *data, uint32_t expect_size,
 
     } while (1);
 
-    /*haven't get any data from fifo */
-    if (recved_len == 0) {
-        return EIO;
-    }
-
     if (recv_size != NULL) {
         *recv_size = recved_len;
     }


### PR DESCRIPTION
[Detail]
hal_uart_recv_II returns 0 if no data received, instead of returning EIO.

[Verified Cases]
Build Pass: eduk1_demo
Test Pass: eduk1_demo
