### PR TITLE
haas1000: disable some bsp log

### DIFF
--- a/hardware/chip/haas1000/aos/aos.c
+++ b/hardware/chip/haas1000/aos/aos.c
@@ -250,7 +250,7 @@ void mcu_first_handshake(void)
 
 int WEAK do_ulog(const unsigned char s, const char *mod, const char *f, const unsigned long l, const char *fmt, va_list args)
 {
-    return 0;
+    return 1;
 }
 int aos_printf_hook(const char *tag, const char *fmt, enum PRINTF_FLAG_T flag, va_list ap)
 {


### PR DESCRIPTION
[Detail]
Disable some haas1000 bsp log

[Verified Cases]
Build Pass: <py_engine_demo>
Test Pass:  <py_engine_demo>