### PR TITLE
[HUST CSE]Add two if sentences about result_start.

### DIFF
--- a/solutions/py_engine_esp32_demo/activation/activation.c
+++ b/solutions/py_engine_esp32_demo/activation/activation.c
@@ -222,6 +222,10 @@ int activation_parse_data(char *response_data)
 
     ACTIVATION_DEBUG("response data: %s\n", response_data);
     result_start = strstr(response_data, ACTIVATION_RESPONSE_RESULT_START);
+    if(result_start == NULL){
+        ACTIVATION_ERR("parse reponse result failed\n");
+        return -1;
+    }
     result_end = strstr(result_start, ACTIVATION_RESPONSE_RESULT_END);
     if ((result_start != NULL)
         && (result_end != NULL)) {
@@ -239,6 +243,10 @@ int activation_parse_data(char *response_data)
         }
 
         result_start = strstr(response_data, ACTIVATION_RESPONSE_MESSAGE_START);
+        if(result_start == NULL){
+            ACTIVATION_ERR("parse reponse result failed\n");
+            return -1;
+        }
         result_end = strstr(result_start, ACTIVATION_RESPONSE_MESSAGE_END);
         if ((result_start != NULL) && (result_end != NULL)) {
             result_start += strlen(ACTIVATION_RESPONSE_MESSAGE_START);


### PR DESCRIPTION
源代码中未单独考虑result_start为空指针的情况。新增了两个关于result_start的if语句，判断result_start是否为空指针。如果未判断，下面调用strstr函数时可能会出现空指针参数，产生错误。