### PR TITLE
[HUST CSE] Fix the error of space size in "memset" function (there are three of them)

### DIFF
--- a/components/amp/engine/duktape_engine/addons/wireless/bt_host/bt_host_adapter.c
+++ b/components/amp/engine/duktape_engine/addons/wireless/bt_host/bt_host_adapter.c
@@ -174,7 +174,7 @@ static ad_data_t *bt_host_adapter_adv_data_parse(char *adv_data, int8_t *num)
     if (ad_data == NULL) {
         return NULL;
     }
-    memset(ad_data, 0, sizeof(ad_num*sizeof(ad_data_t)));
+    memset(ad_data, 0, ad_num*sizeof(ad_data_t));
     ad_num = 0;
     for (i = 0; i < adv_len; ) {
         len = adv_bin[i];

--- a/components/amp/engine/quickjs_engine/addons/wireless/bt_host/bt_host_adapter.c
+++ b/components/amp/engine/quickjs_engine/addons/wireless/bt_host/bt_host_adapter.c
@@ -191,7 +191,7 @@ static ad_data_t *bt_host_adapter_adv_data_parse(char *adv_data, int8_t *num)
     if (ad_data == NULL) {
         return NULL;
     }
-    memset(ad_data, 0, sizeof(ad_num * sizeof(ad_data_t)));
+    memset(ad_data, 0, ad_num * sizeof(ad_data_t));
     ad_num = 0;
     for (i = 0; i < adv_len;) {
         len = adv_bin[i];

--- a/components/amp_adapter/platform/aos/peripheral/aos_hal_gpio.c
+++ b/components/amp_adapter/platform/aos/peripheral/aos_hal_gpio.c
@@ -33,7 +33,7 @@ int32_t aos_hal_gpio_init(gpio_dev_t *gpio)
 
     aos_gpioc_ref_t *gpioc;
     gpioc = aos_malloc(sizeof(aos_gpioc_ref_t));
-    memset(gpioc, 0, sizeof(gpioc));
+    memset(gpioc, 0, sizeof(aos_gpioc_ref_t));
     int32_t pin_index = gpio->port;
     int32_t gpioc_index = 0;
 


### PR DESCRIPTION
源代码中出现了三处memeset函数以字节为单位进行初始化时空间大小分配错误的情况（第三个参数）
不修复会由于第三个参数（空间大小）的错误时部分值初始化失败
路径AliOS-Things/components/amp/engine/duktape_engine/addons/wireless/bt_host/bt_host_adapter.c第177行删去了外层sizeof,
路径AliOS-Things/components/amp/engine/quickjs_engine/addons/wireless/bt_host/bt_host_adapter.c第194行删去了外层sizeof,
路径AliOS-Things/components/amp_adapter/platform/aos/peripheral/aos_hal_gpio.c第36行将sizeof(gpioc)修改为sizeof(aos_gpioc_ref_t)
在vscode环境下成功解决原有问题