### PR TITLE
[play.c]Fix function return value exception

### DIFF
--- a/solutions/tflite_micro_speech_demo/player/player.c
+++ b/solutions/tflite_micro_speech_demo/player/player.c
@@ -125,7 +125,7 @@ int32_t player_play(player_mp3_e file)
     return 0;
 }
 
-int32_t player_stop(void)
+void player_stop(void)
 {
     player_state_t state;
 
@@ -137,7 +137,7 @@ int32_t player_stop(void)
 }
 
 
-int32_t player_wait_complete(void)
+void player_wait_complete(void)
 {
     int32_t ret;
 


### PR DESCRIPTION
函数返回值和类型不匹配

为什么提交这份PR (why to submit this PR)
源文件：solutions/tflite_micro_speech_demo/player/player.c
128行处的player_stop()和140行的player_wait_complete()两个函数中并无返回值，但函数类型为int32，若将该函数值赋予变量时可能会出现bug

你的解决方案是什么 (what is your solution)
将128行和140行处的函数类型由int32改为void


在什么测试环境下测试通过 (what is the test environment)
已通过
