### PR TITLE
Fixed two issue of variable not being initialized which could cause wrong results

### DIFF
--- a/hardware/chip/haas1000/csi/pwm.c
+++ b/hardware/chip/haas1000/csi/pwm.c
@@ -64,7 +64,14 @@ static int pwm_csi_init(void)
     csi_error_t ret;
     static aos_pwm_csi_t pwm_csi_dev[CONFIG_PWM_NUM];
     int i;
+    int idx = 0;
+    RTIM_TimeBaseInitTypeDef TIM_InitStruct;
+    RTIM_TimeBaseStructInit(&TIM_InitStruct);
+    TIM_InitStruct.TIM_Idx = PWM_TIMER;
+    RTIM_TimeBaseInit(CSI_PWM_TIM[idx], &TIM_InitStruct, TIMER5_IRQ, NULL, (u32)&TIM_InitStruct);
+    RTIM_Cmd(CSI_PWM_TIM[idx], ENABLE);
     for (i = 0; i < CONFIG_PWM_NUM; i++) {
+        ret = csi_pwm_init(&(pwm_csi_dev[i].csi_pwm), idx);
         pwm_csi_dev[i].csi_pwm.dev.idx |= (i);
         if (ret != CSI_OK) {
             return ret;

--- a/hardware/chip/haas1000/csi/pwm.c
+++ b/hardware/chip/haas1000/csi/pwm.c
@@ -64,12 +64,6 @@ static int pwm_csi_init(void)
     csi_error_t ret;
     static aos_pwm_csi_t pwm_csi_dev[CONFIG_PWM_NUM];
     int i;
-    int idx = 0;
-    RTIM_TimeBaseInitTypeDef TIM_InitStruct;
-    RTIM_TimeBaseStructInit(&TIM_InitStruct);
-    TIM_InitStruct.TIM_Idx = PWM_TIMER;
-    RTIM_TimeBaseInit(CSI_PWM_TIM[idx], &TIM_InitStruct, TIMER5_IRQ, NULL, (u32)&TIM_InitStruct);
-    RTIM_Cmd(CSI_PWM_TIM[idx], ENABLE);
     for (i = 0; i < CONFIG_PWM_NUM; i++) {
         ret = csi_pwm_init(&(pwm_csi_dev[i].csi_pwm), idx);
         pwm_csi_dev[i].csi_pwm.dev.idx |= (i);

--- a/hardware/chip/rtl872xd/aos_adapter/pwm.c
+++ b/hardware/chip/rtl872xd/aos_adapter/pwm.c
@@ -207,7 +207,7 @@ static const aos_pwm_ops_t rtl872xd_pwm_ops = {
 
 static int rtl872xd_pwm_init(void)
 {
-    int ret;
+    int ret=0;
     static rtl872xd_pwm_t pwm_dev[CONFIG_PWM_NUM];
     int idx = 0, i;
     RTIM_TimeBaseInitTypeDef TIM_InitStruct;
@@ -216,8 +216,13 @@ static int rtl872xd_pwm_init(void)
     RTIM_TimeBaseInit(RTL872xD_PWM_TIM[idx], &TIM_InitStruct, TIMER5_IRQ, NULL, (u32)&TIM_InitStruct);
     RTIM_Cmd(RTL872xD_PWM_TIM[idx], ENABLE);
     for (i = 0; i < CONFIG_PWM_NUM; i++) {
-        pwm_dev[i].priv = (TIM_CCInitTypeDef *)malloc(sizeof(TIM_CCInitTypeDef));
-        pwm_dev[i].idx = idx << BIT_PWM_TIM_IDX_SHIFT;
+        if(!pwm_dev[i] ||IDX!=0){
+            ret=-1;
+        }
+        else{
+            pwm_dev[i].priv = (TIM_CCInitTypeDef *)malloc(sizeof(TIM_CCInitTypeDef));
+            pwm_dev[i].idx = idx << BIT_PWM_TIM_IDX_SHIFT;
+        }
         pwm_dev[i].idx |= (i) & (~BIT_PWM_TIM_IDX_FLAG);
         if (ret != 0) {
             return ret;

--- a/hardware/chip/rtl872xd/aos_adapter/pwm.c
+++ b/hardware/chip/rtl872xd/aos_adapter/pwm.c
@@ -207,7 +207,7 @@ static const aos_pwm_ops_t rtl872xd_pwm_ops = {
 
 static int rtl872xd_pwm_init(void)
 {
-    int ret=0;
+    int ret = 0;
     static rtl872xd_pwm_t pwm_dev[CONFIG_PWM_NUM];
     int idx = 0, i;
     RTIM_TimeBaseInitTypeDef TIM_InitStruct;
@@ -216,10 +216,10 @@ static int rtl872xd_pwm_init(void)
     RTIM_TimeBaseInit(RTL872xD_PWM_TIM[idx], &TIM_InitStruct, TIMER5_IRQ, NULL, (u32)&TIM_InitStruct);
     RTIM_Cmd(RTL872xD_PWM_TIM[idx], ENABLE);
     for (i = 0; i < CONFIG_PWM_NUM; i++) {
-        if(!pwm_dev[i] ||IDX!=0){
-            ret=-1;
+        if (!pwm_dev[i] || IDX != 0) {
+            ret = -1;
         }
-        else{
+        else {
             pwm_dev[i].priv = (TIM_CCInitTypeDef *)malloc(sizeof(TIM_CCInitTypeDef));
             pwm_dev[i].idx = idx << BIT_PWM_TIM_IDX_SHIFT;
         }


### PR DESCRIPTION
**1. 这个PR修复的是什么问题？**
第一处没有对PWM接口进行初始化，没有分配PWM相关资源
第二处虽然分配了PWM相关资源，但对于缺少了相关分配空间是否成功的ret判断
**2. 这个PR不修复具体会带来什么后果？**
未初始化分配资源导致错误
程序流判断错误
**3. PR修复方案的依据是什么？**
第一处使用函数csi_pwn_init( ) 进行初始化
第二处添加if判断保证完成与csi_pwn_init( )源码一样的效果
**4. 在什么环境下测试或者验证过？**
all