### PR TITLE
[HUST CSE] fix: Addresses an issue where functions may not have a ret…

### DIFF
--- a/solutions/eduk1_demo/k1_apps/greedySnake/greedySnake.c
+++ b/solutions/eduk1_demo/k1_apps/greedySnake/greedySnake.c
@@ -415,13 +415,21 @@ icon_t *get_icon_num_5_3(uint8_t num)
             return &icon_9_5_3;
             break;
         default:
+            return &icon_9_5_3;
             break;
     }
 }
 
 void draw_score(uint16_t score)
 {
-    OLED_Icon_Draw(3, 35, get_icon_num_5_3((uint8_t)(score / 100)), 0);
-    OLED_Icon_Draw(3, 31, get_icon_num_5_3((uint8_t)((score % 100) / 10)), 0);
-    OLED_Icon_Draw(3, 27, get_icon_num_5_3((uint8_t)(score % 10)), 0);
+    if(score>999){
+        OLED_Icon_Draw(3, 35, 9, 0);
+        OLED_Icon_Draw(3, 31, 9, 0);
+        OLED_Icon_Draw(3, 27, 9, 0);
+    }else{
+        OLED_Icon_Draw(3, 35, get_icon_num_5_3((uint8_t)(score / 100)), 0);
+        OLED_Icon_Draw(3, 31, get_icon_num_5_3((uint8_t)((score % 100) / 10)), 0);
+        OLED_Icon_Draw(3, 27, get_icon_num_5_3((uint8_t)(score % 10)), 0);
+    }
+
 }


### PR DESCRIPTION
问题：原来的代码无法处理大于999的score，当score大于999时打印第一个得分字符没有返回值
解决方案：首先判断score是否大于999，若大于999直接打印999，否则依据正常流程打印，并将default情况也设置为返回9（但并不会被触发）。