### PR TITLE
[HUST CSE] Fix printf type mismatch

### DIFF
--- a/solutions/ucloud_ai_demo/linkkit_event.c
+++ b/solutions/ucloud_ai_demo/linkkit_event.c
@@ -194,7 +194,7 @@ static void linkkit_dm_recv_handler(void *dm_handle, const aiot_dm_recv_t *recv,
 
         /* 同步服务调用 */
         case AIOT_DMRECV_SYNC_SERVICE_INVOKE: {
-            printf("msg_id = %ld, rrpc_id = %s, service_id = %s, params = %.*s\r\n",
+            printf("msg_id = %lu, rrpc_id = %s, service_id = %s, params = %.*s\r\n",
                    (unsigned long)recv->data.sync_service_invoke.msg_id,
                    recv->data.sync_service_invoke.rrpc_id,
                    recv->data.sync_service_invoke.service_id,


### PR DESCRIPTION
解决了printf输出类型不匹配的问题。
unsigned int 类型应用 %lu 进行格式化输出。