### PR TITLE
Clean cli dependencies

### DIFF
--- a/components/cli/package.yaml
+++ b/components/cli/package.yaml
@@ -10,8 +10,6 @@ license: Apache license v2.0                        # <可选项> 源代码的�
 
 depends:
     - vfs: master ? <CLI_IOBOX_ENABLE>
-    - littlefs: master ? <CLI_IOBOX_ENABLE>
-    - posix: master ? <CLI_IOBOX_ENABLE>
     - uagent: master ? <CLI_UAGENT_ENABLE>
 
 build_config:

--- a/components/cli/src/cli.c
+++ b/components/cli/src/cli.c
@@ -1032,7 +1032,7 @@ void cli_main(void *data)
                    "             Welcome to AliOS Things          ");
     }
 
-#if CLI_IOBOX_ENABLE
+#if CLI_IOBOX_ENABLE && defined(CONFIG_LFS_MOUNTPOINT)
     ret = aos_chdir(CONFIG_LFS_MOUNTPOINT);
     if (ret != 0) {
         cli_printf("Failed to change to %s, errno: %d\r\n",

--- a/components/cli/src/cli_api.h
+++ b/components/cli/src/cli_api.h
@@ -7,6 +7,7 @@
 #define CLI_API_H
 
 #include <stdint.h>
+#include <stdarg.h>
 #include "k_api.h"
 #include "aos/kernel.h"
 #include "aos/cli.h"


### PR DESCRIPTION
Cli doesn't depend on littlefs and posix, clean them.  And make the
other code better.

Change-Id: I14128bc2f3451cd8f97f4fde642d68759e31bd51
Signed-off-by: Yilu Mao <yilu.myl@alibaba-inc.com>
