### PR TITLE
Use only AOS_COMP_WIFI macro

### DIFF
--- a/components/init/aos_init.c
+++ b/components/init/aos_init.c
@@ -133,7 +133,7 @@ static void tcpip_cli_init(void)
     aos_cli_register_commands(&tcpip_cli_cmd[0],sizeof(tcpip_cli_cmd) / sizeof(struct cli_command));
 }
 
-#ifdef AOS_NET_WITH_WIFI
+#if(AOS_COMP_WIFI > 0)
 static uint8_t hex(char c)
 {
     if (c >= '0' && c <= '9')
@@ -152,11 +152,6 @@ static void hexstr2bin(const char *macstr, uint8_t *mac, int len)
         mac[i] = hex(macstr[2 * i]) << 4;
         mac[i] |= hex(macstr[2 * i + 1]);
     }
-}
-
-static void wifi_debug_cmd(char *buf, int len, int argc, char **argv)
-{
-    hal_wifi_start_debug_mode(NULL);
 }
 
 static void mac_cmd(char *buf, int len, int argc, char **argv)
@@ -184,7 +179,6 @@ static void mac_cmd(char *buf, int len, int argc, char **argv)
 
 
 static struct cli_command  wifi_cli_cmd[] = {
-    { "wifi_debug", "wifi debug mode", wifi_debug_cmd },
     { "mac", "get/set mac", mac_cmd },
 };
 
@@ -192,7 +186,7 @@ static void hal_wifi_cli_init(void)
 {
     aos_cli_register_commands(&wifi_cli_cmd[0],sizeof(wifi_cli_cmd) / sizeof(struct cli_command));
 }
-#endif /* AOS_NET_WITH_WIFI */
+#endif /* AOS_COMP_WIFI */
 #endif /* CONFIG_AOS_LWIP */
 #endif /*!defined CONFIG_NO_LWIP */
 
@@ -205,7 +199,7 @@ void cli_service_init(kinit_t *kinit)
 #ifndef CONFIG_NO_LWIP
 #if(CONFIG_AOS_LWIP > 0)
         tcpip_cli_init();
-#ifdef AOS_NET_WITH_WIFI
+#if(AOS_COMP_WIFI > 0)
         hal_wifi_cli_init();
 #endif
 #ifdef IPERF_ENABLED

--- a/components/lwip/lwip2.0.0/apps/iperf/iperf_task.c
+++ b/components/lwip/lwip2.0.0/apps/iperf/iperf_task.c
@@ -9,9 +9,9 @@
 #include "lwip/opt.h"
 #include "iperf_wrapper.h"
 #ifdef AOS_NETMGR_WITH_MODERN
-#ifdef AOS_NET_WITH_WIFI
+#ifdef AOS_COMP_WIFI
 #include "wifi_service.h"
-#endif /* AOS_NET_WITH_WIFI */
+#endif /* AOS_COMP_WIFI */
 #endif /* AOS_NETMGR_WITH_MODERN */
 #include "lwip/debug.h"
 #include "lwip/sockets.h"
@@ -1176,11 +1176,11 @@ void iperf_display_report( char *report_title, unsigned time, unsigned h_ms_time
     aos_cli_printf("%d bits/sec", pkt_count.Bytes );
 
 #ifdef AOS_NETMGR_WITH_MODERN
-#ifdef AOS_NET_WITH_WIFI
+#ifdef AOS_COMP_WIFI
     int rssi;
     wifi_service_get_rssi(&rssi);
     aos_cli_printf(" rssi: %d dBm",  rssi);
-#endif /* AOS_NET_WITH_WIFI */
+#endif /* AOS_COMP_WIFI */
 #endif /* AOS_NETMGR_WITH_MODERN */
 
    aos_cli_printf("\n");

--- a/components/lwip/lwip2.0.0/apps/ping/net_deamon.c
+++ b/components/lwip/lwip2.0.0/apps/ping/net_deamon.c
@@ -11,7 +11,9 @@
 #include "lwip/prot/ip4.h"
 #include "lwip/sockets.h"
 
+#ifdef AOS_COMP_WIFI
 #include "vfsdev/wifi_dev.h"
+#endif
 #include "ulog/ulog.h"
 
 #define PRINT_TAG "net_deamon"
@@ -293,6 +295,7 @@ void start_net_deamon(void)
 
 void get_gw_addr(ip4_addr_t *gw_addr)
 {
+#if AOS_COMP_WIFI
     int ret = 0;
     wifi_ip_stat_t ip_stat = {0};
     //ret = wifi_get_ip_stat(NULL, &ip_stat, STATION);
@@ -305,6 +308,7 @@ void get_gw_addr(ip4_addr_t *gw_addr)
         LWIP_DEBUGF( PING_DEBUG, ("Convert ipaddr addr failed!\n"));
         return;
     }
+#endif
     return;
 }
 void stop_net_deamon(void)

--- a/components/netmgr/activation/activation.c
+++ b/components/netmgr/activation/activation.c
@@ -17,7 +17,9 @@
 #ifdef SYSINFO_MCU_ESP32
 #include "esp_log.h"
 #else
+#ifdef AOS_COMP_WIFI
 #include <vfsdev/wifi_dev.h>
+#endif
 #endif
 
 #define TAG    "ACTIVATION_REPORT"
@@ -178,7 +180,7 @@ int activation_get_report_msg(char *report_msg, int len)
 #ifdef SYSINFO_MCU_ESP32
     extern esp_err_t esp_efuse_mac_get_custom(uint8_t *mac);
     esp_efuse_mac_get_custom(mac);
-#else
+#elif defined(AOS_COMP_WIFI)
     fd = open("/dev/wifi0", O_RDWR);
     if ((fd < 0) || (0 != ioctl(fd, WIFI_DEV_CMD_GET_MAC, mac))) {
         ACTIVATION_ERR("%s:%d WIFI_DEV_CMD_GET_MAC cmd failed!!\n", __func__, __LINE__);

--- a/components/netmgr/package.yaml
+++ b/components/netmgr/package.yaml
@@ -16,11 +16,10 @@ license: Apache license v2.0                        # <可选项> 源代码的�
 depends:                                 # <可选项> 该组件依赖其他的组件，合理的依赖才能保证组件能编译、使用
 #   - minilibc: v7.2.0
 #   - aos: >=v7.2.0
-    - wifi: master
     - osal_aos: master
     - uservice: master
     - sntp: master
-    - posix: master
+    - posix: master ? <AOS_COMP_WIFI>
     - lwip: master
 
 ## 第四部分：编译连接信息
@@ -55,7 +54,7 @@ build_config:
 source_file:
 
   - src/netmgr_service.c
-  - src/netmgr_wifi.c
+  - src/netmgr_wifi.c ? <AOS_COMP_WIFI>
   - src/netmgr_conn.c
   - src/netmgr_ethernet.c
   - src/string_convert.c

--- a/components/netmgr/src/netmgr_ethernet.c
+++ b/components/netmgr/src/netmgr_ethernet.c
@@ -2,8 +2,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <dirent.h>
-#include <unistd.h>
 #include "netmgr.h"
 #include "netmgr_conn.h"
 #include "netmgr_ethernet.h"


### PR DESCRIPTION
1. Clean the old NET_WITH_WIFI macro;
2. Clear the wifi dependency;
3. remove the debug command which is not supported;

Signed-off-by: Yilu Mao <yilu.myl@alibaba-inc.com>
